### PR TITLE
Add uniform distribution for Stiefel/Grassmann, fixes #141

### DIFF
--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -143,7 +143,7 @@ using ManifoldsBase:
 
 
 using Markdown: @doc_str
-using Random: AbstractRNG, randn!
+using Random: AbstractRNG
 using Requires
 using SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
 using StaticArrays

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -143,7 +143,7 @@ using ManifoldsBase:
 
 
 using Markdown: @doc_str
-using Random: AbstractRNG
+using Random: AbstractRNG, randn!
 using Requires
 using SimpleWeightedGraphs: AbstractSimpleWeightedGraph, get_weight
 using StaticArrays

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -384,6 +384,7 @@ show(io::IO, ::Grassmann{n,k,𝔽}) where {n,k,𝔽} = print(io, "Grassmann($(n)
     uniform_distribution(M::Grassmann{n,k,ℝ}, p)
 
 Uniform distribution on given (real-valued) [`Grassmann`](@ref) `M`.
+Specifically, this is the normalized Haar measure on `M`.
 Generated points will be of similar type as `p`.
 
 The implementation is based on Section 2.5.1 in [^Chikuse2003];

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -395,7 +395,13 @@ see also Theorem 2.2.2(iii) in [^Chikuse2003].
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Grassmann{n,k,ℝ}, p) where {n,k}
-    return uniform_distribution(Stiefel(n, k, ℝ), p)
+    μ = Distributions.Zeros(n, k)
+    σ = one(eltype(p))
+    Σ1 = Distributions.PDMats.ScalMat(n, σ)
+    Σ2 = Distributions.PDMats.ScalMat(k, σ)
+    d = MatrixNormal(μ, Σ1, Σ2)
+
+    return ProjectedPointDistribution(M, d, (M, q, p) -> (q .= svd(p).U), p)
 end
 
 @doc raw"""

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -389,3 +389,19 @@ which is given by a zero matrix the same size as `p`.
 zero_tangent_vector(::Grassmann, ::Any...)
 
 zero_tangent_vector!(::Grassmann, X, p) = fill!(X, 0)
+
+"""
+    uniform_distribution(M::Grassmann{n,k,ℝ}, p)
+
+Uniform distribution on given (real-valued) [`Grassmann`](@ref) `M`.
+Generated points will be of similar type as `p`.
+
+The implementation is based on Section 2.5.1 in [^Chikuse2003];
+see also Theorem 2.2.2(iii) in [^Chikuse2003].
+
+[^Chikuse2003]:
+    > Y. Chikuse: "Statistics on Special Manifolds", Springer New York, 2003,
+    > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
+"""
+uniform_distribution(M::Grassmann{n,k,ℝ}, p) where {n,k} =
+    uniform_distribution(Stiefel(n, k, ℝ), p)

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -380,16 +380,6 @@ end
 
 show(io::IO, ::Grassmann{n,k,𝔽}) where {n,k,𝔽} = print(io, "Grassmann($(n), $(k), $(𝔽))")
 
-@doc raw"""
-    zero_tangent_vector(M::Grassmann, p)
-
-Return the zero tangent vector from the tangent space at `p` on the [`Grassmann`](@ref) `M`,
-which is given by a zero matrix the same size as `p`.
-"""
-zero_tangent_vector(::Grassmann, ::Any...)
-
-zero_tangent_vector!(::Grassmann, X, p) = fill!(X, 0)
-
 """
     uniform_distribution(M::Grassmann{n,k,ℝ}, p)
 
@@ -403,5 +393,16 @@ see also Theorem 2.2.2(iii) in [^Chikuse2003].
     > Y. Chikuse: "Statistics on Special Manifolds", Springer New York, 2003,
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
-uniform_distribution(M::Grassmann{n,k,ℝ}, p) where {n,k} =
-    uniform_distribution(Stiefel(n, k, ℝ), p)
+function uniform_distribution(M::Grassmann{n,k,ℝ}, p) where {n,k}
+    return uniform_distribution(Stiefel(n, k, ℝ), p)
+end
+
+@doc raw"""
+    zero_tangent_vector(M::Grassmann, p)
+
+Return the zero tangent vector from the tangent space at `p` on the [`Grassmann`](@ref) `M`,
+which is given by a zero matrix the same size as `p`.
+"""
+zero_tangent_vector(::Grassmann, ::Any...)
+
+zero_tangent_vector!(::Grassmann, X, p) = fill!(X, 0)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -35,7 +35,11 @@ struct Stiefel{n,k,𝔽} <: AbstractEmbeddedManifold{DefaultIsometricEmbeddingTy
 
 Stiefel(n::Int, k::Int, field::AbstractNumbers = ℝ) = Stiefel{n,k,field}()
 
-function allocation_promotion_function(M::Stiefel{n,k,ℂ}, f, args::Tuple) where {n,k}
+function allocation_promotion_function(
+    M::Stiefel{n,k,ℂ},
+    f,
+    args::Tuple,
+) where {n,k}
     return complex
 end
 
@@ -47,8 +51,7 @@ Check whether `p` is a valid point on the [`Stiefel`](@ref) `M`=$\operatorname{S
 complex conjugate transpose. The settings for approximately can be set with `kwargs...`.
 """
 function check_manifold_point(M::Stiefel{n,k,𝔽}, p; kwargs...) where {n,k,𝔽}
-    mpv =
-        invoke(check_manifold_point, Tuple{supertype(typeof(M)),typeof(p)}, M, p; kwargs...)
+    mpv = invoke(check_manifold_point, Tuple{supertype(typeof(M)), typeof(p)}, M, p; kwargs...)
     mpv === nothing || return mpv
     c = p' * p
     if !isapprox(c, one(c); kwargs...)
@@ -81,12 +84,12 @@ function check_tangent_vector(
     end
     mpv = invoke(
         check_tangent_vector,
-        Tuple{supertype(typeof(M)),typeof(p),typeof(X)},
+        Tuple{supertype(typeof(M)), typeof(p), typeof(X)},
         M,
         p,
         X;
         check_base_point = false, # already checked above
-        kwargs...,
+        kwargs...
     )
     mpv === nothing || return mpv
     if !isapprox(p' * X + X' * p, zeros(k, k); kwargs...)
@@ -331,11 +334,11 @@ see also Theorem 2.2.1(iii) in [^Chikuse2003].
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    μ = Distributions.Zeros(n, k)
+    μ = Distributions.Zeros(n,k)
     σ = one(eltype(p))
-    Σ1 = Distributions.PDMats.ScalMat(n, σ)
-    Σ2 = Distributions.PDMats.ScalMat(k, σ)
-    d = MatrixNormal(μ, Σ1, Σ2)
+    Σ1 = Distributions.PDMats.ScalMat(n,σ)
+    Σ2 = Distributions.PDMats.ScalMat(k,σ)
+    d = MatrixNormal(μ,Σ1,Σ2)
 
     return ProjectedPointDistribution(M, d, project!, p)
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -334,8 +334,8 @@ The implementation is based on Section 2.5.1 in [^Chikuse2003].
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
     μ = Distributions.Zeros(p)
     σ = one(eltype(p))
-    Σ1 = Distributions.PDMats.ScalMat(size(p,1),σ)
-    Σ2 = Distributions.PDMats.ScalMat(size(p,2),σ)
+    Σ1 = Distributions.PDMats.ScalMat(n,σ)
+    Σ2 = Distributions.PDMats.ScalMat(k,σ)
     d = MatrixNormal(μ,Σ1,Σ2)
 
     return ProjectedPointDistribution(M, d, project!, p)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -324,6 +324,12 @@ show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(
 
 Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
 Generated points will be of similar type as `p`.
+
+The implementation is based on Section 2.5.1 in [^Chikuse2003].
+
+[^Chikuse2003]:
+    > Y. Chikuse: "Statistics on Special Manifolds", Springer New York, 2003,
+    > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
     μ = Distributions.Zeros(p)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -320,12 +320,12 @@ i.e. `(n,k)`, which is the matrix dimensions.
 show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(F))")
 
 """
-    uniform_distribution(M::Stiefel, p)
+    uniform_distribution(M::Stiefel{n,k,ℝ}, p)
 
-Uniform distribution on given [`Stiefel`](@ref) `M`. Generated points will be of
-similar type as `p`.
+Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
+Generated points will be of similar type as `p`.
 """
-function uniform_distribution(M::Stiefel, p)
+function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
     d = RandnMatrix(size(p)...)
     return ProjectedPointDistribution(M, d, project!, p)
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -326,15 +326,17 @@ Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
 Generated points will be of similar type as `p`.
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    d = MatrixStandardNormal{size(p)...}()
+    d = MatrixStandardNormal{eltype(p),size(p)...}()
     return ProjectedPointDistribution(M, d, project!, p)
 end
 
-struct MatrixStandardNormal{N,M} <: ContinuousMatrixDistribution end
-Base.size(d::MatrixStandardNormal{N,M}) where {N,M} = (N,M)
+struct MatrixStandardNormal{T<:AbstractFloat,N,M} <: ContinuousMatrixDistribution end
+Base.size(d::MatrixStandardNormal{T,N,M}) where {T,N,M} = (N,M)
 Base.size(d::MatrixStandardNormal, i) = i::Integer <= 2 ? size(d)[i] : 1
-Distributions._rand!(rng::AbstractRNG, d::MatrixStandardNormal, A::AbstractMatrix) = randn!(rng,A)
-function Distributions._logpdf(d::MatrixStandardNormal, x::AbstractArray)
+Base.eltype(::MatrixStandardNormal{T}) where {T} = T
+Distributions._rand!(rng::AbstractRNG, d::MatrixStandardNormal{T},
+    A::AbstractMatrix{T}) where {T} = randn!(rng,A)
+function Distributions._logpdf(d::MatrixStandardNormal{T}, x::AbstractArray{T}) where {T}
     dim = length(d)
     σ = one(eltype(x))
     dvec = MvNormal(dim, σ)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -323,6 +323,7 @@ show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(
     uniform_distribution(M::Stiefel{n,k,ℝ}, p)
 
 Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
+Specifically, this is the normalized Haar and Hausdorff measure on `M`.
 Generated points will be of similar type as `p`.
 
 The implementation is based on Section 2.5.1 in [^Chikuse2003].

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -334,7 +334,9 @@ struct MatrixStandardNormal{N,M} <: ContinuousMatrixDistribution end
 Base.size(d::RandnMatrix) = (d.n,d.m)
 Base.size(d::RandnMatrix, i) = i::Integer <= 2 ? size(d)[i] : 1
 Distributions._rand!(rng::AbstractRNG, d::RandnMatrix, A::AbstractMatrix) = randn!(rng,A)
-Distributions._logpdf(d::RandnMatrix, x::AbstractArray) = sum(x) do xij
-    dij = Distributions.Normal(zero(xij),one(xij))
-    return Distributions.logpdf(dij,xij)
+function Distributions._logpdf(d::RandnMatrix, x::AbstractArray)
+    dim = prod(size(d))
+    σ = one(eltype(x))
+    dvec = MvNormal(dim, σ)
+    return Distributions._logpdf(dvec, vec(x))
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -335,7 +335,7 @@ Base.size(d::MatrixStandardNormal{N,M}) where {N,M} = (N,M)
 Base.size(d::MatrixStandardNormal, i) = i::Integer <= 2 ? size(d)[i] : 1
 Distributions._rand!(rng::AbstractRNG, d::MatrixStandardNormal, A::AbstractMatrix) = randn!(rng,A)
 function Distributions._logpdf(d::MatrixStandardNormal, x::AbstractArray)
-    dim = prod(size(d))
+    dim = length(d)
     σ = one(eltype(x))
     dvec = MvNormal(dim, σ)
     return Distributions._logpdf(dvec, vec(x))

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -35,11 +35,7 @@ struct Stiefel{n,k,𝔽} <: AbstractEmbeddedManifold{DefaultIsometricEmbeddingTy
 
 Stiefel(n::Int, k::Int, field::AbstractNumbers = ℝ) = Stiefel{n,k,field}()
 
-function allocation_promotion_function(
-    M::Stiefel{n,k,ℂ},
-    f,
-    args::Tuple,
-) where {n,k}
+function allocation_promotion_function(M::Stiefel{n,k,ℂ}, f, args::Tuple) where {n,k}
     return complex
 end
 
@@ -51,7 +47,8 @@ Check whether `p` is a valid point on the [`Stiefel`](@ref) `M`=$\operatorname{S
 complex conjugate transpose. The settings for approximately can be set with `kwargs...`.
 """
 function check_manifold_point(M::Stiefel{n,k,𝔽}, p; kwargs...) where {n,k,𝔽}
-    mpv = invoke(check_manifold_point, Tuple{supertype(typeof(M)), typeof(p)}, M, p; kwargs...)
+    mpv =
+        invoke(check_manifold_point, Tuple{supertype(typeof(M)),typeof(p)}, M, p; kwargs...)
     mpv === nothing || return mpv
     c = p' * p
     if !isapprox(c, one(c); kwargs...)
@@ -84,12 +81,12 @@ function check_tangent_vector(
     end
     mpv = invoke(
         check_tangent_vector,
-        Tuple{supertype(typeof(M)), typeof(p), typeof(X)},
+        Tuple{supertype(typeof(M)),typeof(p),typeof(X)},
         M,
         p,
         X;
         check_base_point = false, # already checked above
-        kwargs...
+        kwargs...,
     )
     mpv === nothing || return mpv
     if !isapprox(p' * X + X' * p, zeros(k, k); kwargs...)
@@ -333,11 +330,11 @@ The implementation is based on Section 2.5.1 in [^Chikuse2003].
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    μ = Distributions.Zeros(n,k)
+    μ = Distributions.Zeros(n, k)
     σ = one(eltype(p))
-    Σ1 = Distributions.PDMats.ScalMat(n,σ)
-    Σ2 = Distributions.PDMats.ScalMat(k,σ)
-    d = MatrixNormal(μ,Σ1,Σ2)
+    Σ1 = Distributions.PDMats.ScalMat(n, σ)
+    Σ2 = Distributions.PDMats.ScalMat(k, σ)
+    d = MatrixNormal(μ, Σ1, Σ2)
 
     return ProjectedPointDistribution(M, d, project!, p)
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -326,19 +326,11 @@ Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
 Generated points will be of similar type as `p`.
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    d = MatrixStandardNormal{eltype(p),size(p)...}()
-    return ProjectedPointDistribution(M, d, project!, p)
-end
+    μ = Distributions.Zeros(p)
+    σ = one(eltype(p))
+    Σ1 = Distributions.PDMats.ScalMat(size(p,1),σ)
+    Σ2 = Distributions.PDMats.ScalMat(size(p,2),σ)
+    d = MatrixNormal(μ,Σ1,Σ2)
 
-struct MatrixStandardNormal{T<:AbstractFloat,N,M} <: ContinuousMatrixDistribution end
-Base.size(d::MatrixStandardNormal{T,N,M}) where {T,N,M} = (N,M)
-Base.size(d::MatrixStandardNormal, i) = i::Integer <= 2 ? size(d)[i] : 1
-Base.eltype(::MatrixStandardNormal{T}) where {T} = T
-Distributions._rand!(rng::AbstractRNG, d::MatrixStandardNormal{T},
-    A::AbstractMatrix{T}) where {T} = randn!(rng,A)
-function Distributions._logpdf(d::MatrixStandardNormal{T}, x::AbstractArray{T}) where {T}
-    dim = length(d)
-    σ = one(eltype(x))
-    dvec = MvNormal(dim, σ)
-    return Distributions._logpdf(dvec, vec(x))
+    return ProjectedPointDistribution(M, d, project!, p)
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -326,15 +326,15 @@ Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
 Generated points will be of similar type as `p`.
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    d = RandnMatrix(size(p)...)
+    d = MatrixStandardNormal{size(p)...}()
     return ProjectedPointDistribution(M, d, project!, p)
 end
 
 struct MatrixStandardNormal{N,M} <: ContinuousMatrixDistribution end
-Base.size(d::RandnMatrix) = (d.n,d.m)
-Base.size(d::RandnMatrix, i) = i::Integer <= 2 ? size(d)[i] : 1
-Distributions._rand!(rng::AbstractRNG, d::RandnMatrix, A::AbstractMatrix) = randn!(rng,A)
-function Distributions._logpdf(d::RandnMatrix, x::AbstractArray)
+Base.size(d::MatrixStandardNormal{N,M}) where {N,M} = (N,M)
+Base.size(d::MatrixStandardNormal, i) = i::Integer <= 2 ? size(d)[i] : 1
+Distributions._rand!(rng::AbstractRNG, d::MatrixStandardNormal, A::AbstractMatrix) = randn!(rng,A)
+function Distributions._logpdf(d::MatrixStandardNormal, x::AbstractArray)
     dim = prod(size(d))
     σ = one(eltype(x))
     dvec = MvNormal(dim, σ)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -334,11 +334,11 @@ see also Theorem 2.2.1(iii) in [^Chikuse2003].
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    μ = Distributions.Zeros(n,k)
+    μ = Distributions.Zeros(n, k)
     σ = one(eltype(p))
-    Σ1 = Distributions.PDMats.ScalMat(n,σ)
-    Σ2 = Distributions.PDMats.ScalMat(k,σ)
-    d = MatrixNormal(μ,Σ1,Σ2)
+    Σ1 = Distributions.PDMats.ScalMat(n, σ)
+    Σ2 = Distributions.PDMats.ScalMat(k, σ)
+    d = MatrixNormal(μ, Σ1, Σ2)
 
     return ProjectedPointDistribution(M, d, project!, p)
 end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -332,7 +332,7 @@ The implementation is based on Section 2.5.1 in [^Chikuse2003].
     > doi: [10.1007/978-0-387-21540-2](https://doi.org/10.1007/978-0-387-21540-2).
 """
 function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
-    μ = Distributions.Zeros(p)
+    μ = Distributions.Zeros(n,k)
     σ = one(eltype(p))
     Σ1 = Distributions.PDMats.ScalMat(n,σ)
     Σ2 = Distributions.PDMats.ScalMat(k,σ)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -330,10 +330,7 @@ function uniform_distribution(M::Stiefel{n,k,ℝ}, p) where {n,k}
     return ProjectedPointDistribution(M, d, project!, p)
 end
 
-struct RandnMatrix <: ContinuousMatrixDistribution
-    n::Integer
-    m::Integer
-end
+struct MatrixStandardNormal{N,M} <: ContinuousMatrixDistribution end
 Base.size(d::RandnMatrix) = (d.n,d.m)
 Base.size(d::RandnMatrix, i) = i::Integer <= 2 ? size(d)[i] : 1
 Distributions._rand!(rng::AbstractRNG, d::RandnMatrix, A::AbstractMatrix) = randn!(rng,A)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -318,3 +318,26 @@ i.e. `(n,k)`, which is the matrix dimensions.
 @generated representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
 
 show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(F))")
+
+"""
+    uniform_distribution(M::Stiefel, p)
+
+Uniform distribution on given [`Stiefel`](@ref) `M`. Generated points will be of
+similar type as `p`.
+"""
+function uniform_distribution(M::Stiefel, p)
+    d = RandnMatrix(size(p)...)
+    return ProjectedPointDistribution(M, d, project!, p)
+end
+
+struct RandnMatrix <: ContinuousMatrixDistribution
+    n::Integer
+    m::Integer
+end
+Base.size(d::RandnMatrix) = (d.n,d.m)
+Base.size(d::RandnMatrix, i) = i::Integer <= 2 ? size(d)[i] : 1
+Distributions._rand!(rng::AbstractRNG, d::RandnMatrix, A::AbstractMatrix) = randn!(rng,A)
+Distributions._logpdf(d::RandnMatrix, x::AbstractArray) = sum(x) do xij
+    dij = Distributions.Normal(zero(xij),one(xij))
+    return Distributions.logpdf(dij,xij)
+end

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -323,7 +323,8 @@ Uniform distribution on given (real-valued) [`Stiefel`](@ref) `M`.
 Specifically, this is the normalized Haar and Hausdorff measure on `M`.
 Generated points will be of similar type as `p`.
 
-The implementation is based on Section 2.5.1 in [^Chikuse2003].
+The implementation is based on Section 2.5.1 in [^Chikuse2003];
+see also Theorem 2.2.1(iii) in [^Chikuse2003].
 
 [^Chikuse2003]:
     > Y. Chikuse: "Statistics on Special Manifolds", Springer New York, 2003,

--- a/test/grassmann.jl
+++ b/test/grassmann.jl
@@ -40,6 +40,7 @@ include("utils.jl")
                 test_injectivity_radius = false,
                 test_project_tangent = true,
                 test_vector_transport = false,
+                point_distributions = [Manifolds.uniform_distribution(M, pts[1])],
                 test_forward_diff = false,
                 test_reverse_diff = false,
                 test_vee_hat = false,
@@ -61,6 +62,11 @@ include("utils.jl")
                 @test norm(M, pts[1], v1) isa Real
                 @test norm(M, pts[1], v1) ≈ sqrt(inner(M, pts[1], v1, v1))
             end
+        end
+
+        @testset "Distribution tests" begin
+            ugd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [1.0 0.0; 0.0 1.0; 0.0 0.0])
+            @test isa(rand(ugd_mmatrix), MMatrix)
         end
     end
 

--- a/test/grassmann.jl
+++ b/test/grassmann.jl
@@ -65,7 +65,11 @@ include("utils.jl")
         end
 
         @testset "Distribution tests" begin
-            ugd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [1.0 0.0; 0.0 1.0; 0.0 0.0])
+            ugd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [
+                1.0 0.0
+                0.0 1.0
+                0.0 0.0
+            ])
             @test isa(rand(ugd_mmatrix), MMatrix)
         end
     end

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -70,6 +70,7 @@ include("utils.jl")
                 test_is_tangent = true,
                 test_project_tangent = true,
                 test_vector_transport = false,
+                point_distributions = [Manifolds.uniform_distribution(M, pts[1])],
                 test_forward_diff = false,
                 test_reverse_diff = false,
                 test_vee_hat = false,
@@ -94,6 +95,11 @@ include("utils.jl")
                 @test norm(M, pts[1], v1) isa Real
                 @test norm(M, pts[1], v1) ≈ sqrt(inner(M, pts[1], v1, v1))
             end
+        end
+
+        @testset "Distribution tests" begin
+            usd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [1.0 0.0; 0.0 1.0; 0.0 0.0])
+            @test isa(rand(usd_mmatrix), MMatrix)
         end
     end
 

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -98,7 +98,11 @@ include("utils.jl")
         end
 
         @testset "Distribution tests" begin
-            usd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [1.0 0.0; 0.0 1.0; 0.0 0.0])
+            usd_mmatrix = Manifolds.uniform_distribution(M, @MMatrix [
+                1.0 0.0
+                0.0 1.0
+                0.0 0.0
+            ])
             @test isa(rand(usd_mmatrix), MMatrix)
         end
     end


### PR DESCRIPTION
Fixes #141 

Added `uniform_distribution` for `Stiefel` following the example for `Sphere`. In order to fit within the `ProjectedPointDistribution` framework, created a thin wrapper around `randn` called (for now) `RandnMatrix`. Happy to iterate on this, not sure if it's the best way!

Some todos:
+ [x] ~~(maybe) simplify implementation of `project!(M::Stiefel, q, p)` to eliminate (potentially unnecessary) eigendecomposition of U'U = I (up to numerical errors).~~ (new pr: #153)
+ [x] ~~complex-valued case? (currently not handled)~~ (new issue: #152)
+ [x] Grassmann (should be easy once we're happy with the Stiefel)
+ [x] ~~(maybe) tackle generalized Stiefel/Grassmann~~ (new issue: #152)
+ [x] tests (will likely follow whatever is done for `Sphere`)