### PR TITLE
Simplify project! for Stiefel

### DIFF
--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -235,7 +235,7 @@ project(::Stiefel, ::Any, ::Any)
 
 function project!(M::Stiefel, q, p)
     s = svd(p)
-    q .= s.U * s.V'
+    mul!(q, s.U, s.Vt)
     return q
 end
 

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -235,9 +235,7 @@ project(::Stiefel, ::Any, ::Any)
 
 function project!(M::Stiefel, q, p)
     s = svd(p)
-    e = eigen(s.U' * s.U)
-    qsinv = e.vectors * Diagonal(1 ./ sqrt.(e.values))
-    q .= s.U * qsinv * e.vectors' * s.V'
+    q .= s.U * s.V'
     return q
 end
 


### PR DESCRIPTION
Do simplifications of `project!` method discussed in #141 and mentioned in #142.

Key idea is that `s.U' * s.U` in the previous implementation should (up to numerical issues) be approximately `I` in which case the remaining code simplifies.