### PR TITLE
Reformat `@invoke_maker` calls

### DIFF
--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -256,15 +256,17 @@ function get_vector!(M::Manifold, Y, e::Identity, X, B::VeeOrthogonalBasis)
     return get_vector!(M, Y, e.p, X, B)
 end
 for MT in GROUP_MANIFOLD_BASIS_DISAMBIGUATION
-    eval(quote
-        @invoke_maker 1 Manifold get_vector!(
-            M::$MT,
-            Y,
-            e::Identity,
-            X,
-            B::VeeOrthogonalBasis,
-        )
-    end)
+    eval(
+        quote
+            @invoke_maker 1 Manifold get_vector!(
+                M::$MT,
+                Y,
+                e::Identity,
+                X,
+                B::VeeOrthogonalBasis,
+            )
+        end,
+    )
 end
 
 function get_coordinates(M::AbstractGroupManifold, e::Identity, X, B::VeeOrthogonalBasis)
@@ -278,14 +280,16 @@ function get_coordinates(M::Manifold, e::Identity, X, B::VeeOrthogonalBasis)
     return get_coordinates(M, e.p, X, B)
 end
 for MT in GROUP_MANIFOLD_BASIS_DISAMBIGUATION
-    eval(quote
-        @invoke_maker 1 Manifold get_coordinates(
-            M::$MT,
-            e::Identity,
-            X,
-            B::VeeOrthogonalBasis,
-        )
-    end)
+    eval(
+        quote
+            @invoke_maker 1 Manifold get_coordinates(
+                M::$MT,
+                e::Identity,
+                X,
+                B::VeeOrthogonalBasis,
+            )
+        end,
+    )
 end
 
 function get_coordinates!(
@@ -305,15 +309,17 @@ function get_coordinates!(M::Manifold, Y, e::Identity, X, B::VeeOrthogonalBasis)
     return get_coordinates!(M, Y, e.p, X, B)
 end
 for MT in GROUP_MANIFOLD_BASIS_DISAMBIGUATION
-    eval(quote
-        @invoke_maker 1 Manifold get_coordinates!(
-            M::$MT,
-            Y,
-            e::Identity,
-            X,
-            B::VeeOrthogonalBasis,
-        )
-    end)
+    eval(
+        quote
+            @invoke_maker 1 Manifold get_coordinates!(
+                M::$MT,
+                Y,
+                e::Identity,
+                X,
+                B::VeeOrthogonalBasis,
+            )
+        end,
+    )
 end
 
 import ManifoldsBase.check_manifold_point__transparent

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -141,15 +141,17 @@ function get_vector!(G::SemidirectProductGroup, Y, p, X, B::VeeOrthogonalBasis)
     @inbounds _padvector!(G, Y)
     return Y
 end
-eval(quote
-    @invoke_maker 1 Manifold get_vector!(
-        M::SemidirectProductGroup,
-        Xⁱ,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_vector!(
+            M::SemidirectProductGroup,
+            Xⁱ,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 function get_coordinates!(G::SemidirectProductGroup, Y, p, X, B::VeeOrthogonalBasis)
     M = base_manifold(G)

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -150,14 +150,16 @@ function get_coordinates(M::Circle{ℂ}, p, X, B::DefaultOrthonormalBasis)
     return @SVector [Xⁱ]
 end
 
-eval(quote
-    @invoke_maker 1 Manifold get_coordinates(
-        M::Circle,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_coordinates(
+            M::Circle,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 function get_coordinates!(M::Circle, Y::AbstractArray, p, X, B::DefaultOrthonormalBasis)
     Y[] = get_coordinates(M, p, X, B)[]
@@ -174,15 +176,17 @@ function get_coordinates!(
     return Y
 end
 
-eval(quote
-    @invoke_maker 1 Manifold get_coordinates!(
-        M::Circle,
-        Y::AbstractArray,
-        p,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_coordinates!(
+            M::Circle,
+            Y::AbstractArray,
+            p,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 
 get_vector(M::Circle{ℝ}, p, X, B::AbstractBasis) = X
@@ -203,15 +207,17 @@ function get_vector!(M::Circle, Y::AbstractArray, p, X, B::AbstractBasis)
     return Y
 end
 for BT in ManifoldsBase.DISAMBIGUATION_BASIS_TYPES
-    eval(quote
-        @invoke_maker 5 $(supertype(BT)) get_vector!(
-            M::Circle,
-            Y::AbstractArray,
-            p,
-            X,
-            B::$BT,
-        )
-    end)
+    eval(
+        quote
+            @invoke_maker 5 $(supertype(BT)) get_vector!(
+                M::Circle,
+                Y::AbstractArray,
+                p,
+                X,
+                B::$BT,
+            )
+        end,
+    )
 end
 
 @doc raw"""
@@ -223,9 +229,14 @@ injectivity_radius(::Circle) = π
 injectivity_radius(::Circle, ::ExponentialRetraction) = π
 injectivity_radius(::Circle, ::Any) = π
 injectivity_radius(::Circle, ::Any, ::ExponentialRetraction) = π
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(M::Circle, rm::AbstractRetractionMethod)
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::Circle,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     inner(M::Circle, p, X, Y)

--- a/src/manifolds/GeneralizedGrassmann.jl
+++ b/src/manifolds/GeneralizedGrassmann.jl
@@ -197,12 +197,14 @@ injectivity_radius(::GeneralizedGrassmann) = π / 2
 injectivity_radius(::GeneralizedGrassmann, ::ExponentialRetraction) = π / 2
 injectivity_radius(::GeneralizedGrassmann, ::Any) = π / 2
 injectivity_radius(::GeneralizedGrassmann, ::Any, ::ExponentialRetraction) = π / 2
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::GeneralizedGrassmann,
-        rm::AbstractRetractionMethod,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::GeneralizedGrassmann,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     inner(M::GeneralizedGrassmann, p, X, Y)

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -192,9 +192,14 @@ injectivity_radius(::Grassmann) = π / 2
 injectivity_radius(::Grassmann, ::ExponentialRetraction) = π / 2
 injectivity_radius(::Grassmann, ::Any) = π / 2
 injectivity_radius(::Grassmann, ::Any, ::ExponentialRetraction) = π / 2
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(M::Grassmann, rm::AbstractRetractionMethod)
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::Grassmann,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     inner(M::Grassmann, p, X, Y)

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -139,12 +139,14 @@ injectivity_radius(H::Hyperbolic) = Inf
 injectivity_radius(H::Hyperbolic, ::ExponentialRetraction) = Inf
 injectivity_radius(H::Hyperbolic, ::Any) = Inf
 injectivity_radius(H::Hyperbolic, ::Any, ::ExponentialRetraction) = Inf
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::Hyperbolic,
-        rm::AbstractRetractionMethod,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::Hyperbolic,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     log(M::Hyperbolic, p, q)

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -478,18 +478,22 @@ function injectivity_radius(M::AbstractPowerManifold, p)
     return radius
 end
 injectivity_radius(M::AbstractPowerManifold) = injectivity_radius(M.manifold)
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::AbstractPowerManifold,
-        rm::AbstractRetractionMethod,
-    )
-end)
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::AbstractPowerManifold,
-        rm::ExponentialRetraction,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::AbstractPowerManifold,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::AbstractPowerManifold,
+            rm::ExponentialRetraction,
+        )
+    end,
+)
 
 @doc raw"""
     inverse_retract(M::AbstractPowerManifold, p, q, m::InversePowerRetraction)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -316,14 +316,16 @@ for BT in PRODUCT_BASIS_LIST_CACHED
         end,
     )
 end
-eval(quote
-    @invoke_maker 1 Manifold get_coordinates(
-        M::ProductManifold,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_coordinates(
+            M::ProductManifold,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 function get_coordinates(M::ProductManifold, p, X, B::AbstractBasis)
     reps = map(
@@ -390,25 +392,29 @@ for BT in PRODUCT_BASIS_LIST_CACHED
     )
 end
 for BT in PRODUCT_BASIS_LIST
-    eval(quote
-        @invoke_maker 5 AbstractBasis get_coordinates!(
-            M::ProductManifold,
-            Xⁱ,
-            p,
-            X,
-            B::$BT,
-        )
-    end)
-end
-eval(quote
-    @invoke_maker 1 Manifold get_coordinates!(
-        M::ProductManifold,
-        Y,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
+    eval(
+        quote
+            @invoke_maker 5 AbstractBasis get_coordinates!(
+                M::ProductManifold,
+                Xⁱ,
+                p,
+                X,
+                B::$BT,
+            )
+        end,
     )
-end)
+end
+eval(
+    quote
+        @invoke_maker 1 Manifold get_coordinates!(
+            M::ProductManifold,
+            Y,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 function get_vector(
     M::ProductManifold,
@@ -439,14 +445,16 @@ eval(
         )
     end,
 )
-eval(quote
-    @invoke_maker 1 Manifold get_vector(
-        M::ProductManifold,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_vector(
+            M::ProductManifold,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 function get_vector(M::ProductManifold, p::ProductRepr, X, B::AbstractBasis)
     N = number_of_components(M)
     dims = map(manifold_dimension, M.manifolds)
@@ -515,15 +523,17 @@ function get_vector!(
     end
     return X
 end
-eval(quote
-    @invoke_maker 1 Manifold get_vector!(
-        M::ProductManifold,
-        Xⁱ,
-        e::Identity,
-        X,
-        B::VeeOrthogonalBasis,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold get_vector!(
+            M::ProductManifold,
+            Xⁱ,
+            e::Identity,
+            X,
+            B::VeeOrthogonalBasis,
+        )
+    end,
+)
 
 for BT in PRODUCT_BASIS_LIST
     eval(
@@ -578,13 +588,15 @@ function injectivity_radius(M::ProductManifold, p, m::ProductRetraction)
         m.retractions,
     )...)
 end
-eval(quote
-    @invoke_maker 3 AbstractRetractionMethod injectivity_radius(
-        M::ProductManifold,
-        p,
-        B::ExponentialRetraction,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 3 AbstractRetractionMethod injectivity_radius(
+            M::ProductManifold,
+            p,
+            B::ExponentialRetraction,
+        )
+    end,
+)
 injectivity_radius(M::ProductManifold) = min(map(injectivity_radius, M.manifolds)...)
 function injectivity_radius(M::ProductManifold, m::AbstractRetractionMethod)
     return min(map(manif -> injectivity_radius(manif, m), M.manifolds)...)
@@ -592,12 +604,14 @@ end
 function injectivity_radius(M::ProductManifold, m::ProductRetraction)
     return min(map((lM, lm) -> injectivity_radius(lM, lm), M.manifolds, m.retractions)...)
 end
-eval(quote
-    @invoke_maker 2 AbstractRetractionMethod injectivity_radius(
-        M::ProductManifold,
-        B::ExponentialRetraction,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 2 AbstractRetractionMethod injectivity_radius(
+            M::ProductManifold,
+            B::ExponentialRetraction,
+        )
+    end,
+)
 
 @doc raw"""
     inner(M::ProductManifold, p, X, Y)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -364,9 +364,14 @@ Return the radius of injectivity for the [`PolarRetraction`](@ref) on the
 """
 injectivity_radius(::Rotations) = π * sqrt(2.0)
 injectivity_radius(::Rotations, ::ExponentialRetraction) = π * sqrt(2.0)
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(M::Rotations, rm::AbstractRetractionMethod)
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::Rotations,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 injectivity_radius(::Rotations, ::Any) = π * sqrt(2.0)
 injectivity_radius(::Rotations, ::Any, ::ExponentialRetraction) = π * sqrt(2.0)
 injectivity_radius(::Rotations, ::PolarRetraction) = π / sqrt(2.0)

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -249,12 +249,14 @@ injectivity_radius(::AbstractSphere, ::ProjectionRetraction) = π / 2
 injectivity_radius(::AbstractSphere, ::Any) = π
 injectivity_radius(::AbstractSphere, ::Any, ::ExponentialRetraction) = π
 injectivity_radius(::AbstractSphere, ::Any, ::ProjectionRetraction) = π / 2
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::AbstractSphere,
-        rm::AbstractRetractionMethod,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::AbstractSphere,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     inverse_retract(M::AbstractSphere, p, q, ::ProjectionInverseRetraction)

--- a/src/manifolds/SymmetricPositiveDefinite.jl
+++ b/src/manifolds/SymmetricPositiveDefinite.jl
@@ -106,12 +106,14 @@ injectivity_radius(::SymmetricPositiveDefinite) = Inf
 injectivity_radius(::SymmetricPositiveDefinite, ::ExponentialRetraction) = Inf
 injectivity_radius(::SymmetricPositiveDefinite, ::Any) = Inf
 injectivity_radius(::SymmetricPositiveDefinite, ::Any, ::ExponentialRetraction) = Inf
-eval(quote
-    @invoke_maker 1 Manifold injectivity_radius(
-        M::SymmetricPositiveDefinite,
-        rm::AbstractRetractionMethod,
-    )
-end)
+eval(
+    quote
+        @invoke_maker 1 Manifold injectivity_radius(
+            M::SymmetricPositiveDefinite,
+            rm::AbstractRetractionMethod,
+        )
+    end,
+)
 
 @doc raw"""
     manifold_dimension(M::SymmetricPositiveDefinite)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -340,9 +340,17 @@ for BT in [
     ProjectedOrthonormalBasis{:svd,ℝ},
     VeeOrthogonalBasis,
 ]
-    eval(quote
-        @invoke_maker 5 AbstractBasis get_coordinates!(M::VectorBundle, Y, p, X, B::$BT)
-    end)
+    eval(
+        quote
+            @invoke_maker 5 AbstractBasis get_coordinates!(
+                M::VectorBundle,
+                Y,
+                p,
+                X,
+                B::$BT,
+            )
+        end,
+    )
 end
 function get_coordinates!(M::VectorBundle, Y, p, X, B::CachedBasis)
     error("get_coordinates! called on $M with an incorrect CachedBasis. Expected a CachedBasis with VectorBundleBasisData, given $B")


### PR DESCRIPTION
JuliaFormatter v0.4.1 fixed the issue we had with `@invoke_maker` calls always being reformatted, so this updates the final format (and _should_ make the Format workflow pass).