### PR TITLE
Upper-bound FiniteDifferences

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distributions = "0.22, 0.23"
 Einsum = "0.4"
-FiniteDifferences = "0.9"
+FiniteDifferences = "< 0.9.3"
 HybridArrays = "0.3"
 LightGraphs = "1"
 ManifoldsBase = "0.8.1"


### PR DESCRIPTION
Temporarily upper-bound FiniteDifferences until https://github.com/JuliaDiff/FiniteDifferences.jl/issues/67 is resolved. I don't think this should be part of a release, just so our CI passes.