### PR TITLE
Bug in check_manifold_point for FixedRankMatrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -144,15 +144,15 @@ function check_manifold_point(
             ),
         )
     end
-    if !isapprox(x.U' * x.U, one(zeros(n, n)); kwargs...)
+    if !isapprox(x.U' * x.U, one(zeros(k, k)); kwargs...)
         return DomainError(
-            norm(x.U' * x.U - one(zeros(n, n))),
+            norm(x.U' * x.U - one(zeros(k, k))),
             string(s, " since U is not orthonormal/unitary."),
         )
     end
-    if !isapprox(x.Vt' * x.Vt, one(zeros(n, n)); kwargs...)
+    if !isapprox(x.Vt * x.Vt', one(zeros(k, k)); kwargs...)
         return DomainError(
-            norm(x.Vt' * x.Vt - one(zeros(n, n))),
+            norm(x.Vt * x.Vt' - one(zeros(k, k))),
             string(s, " since V is not orthonormal/unitary."),
         )
     end

--- a/test/fixed_rank.jl
+++ b/test/fixed_rank.jl
@@ -2,8 +2,10 @@ include("utils.jl")
 
 @testset "fixed Rank" begin
     M = FixedRankMatrices(3, 2, 2)
+    M2 = FixedRankMatrices(3, 2, 1)
     Mc = FixedRankMatrices(3, 2, 2, ℂ)
     x = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0])
+    x2 = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0],1)
     v = UMVTVector([0.0 0.0; 0.0 0.0; 1.0 1.0], [1.0 0.0; 0.0 1.0], zeros(2, 2))
     @test repr(M) == "FixedRankMatrices(3, 2, 2, ℝ)"
     @test repr(Mc) == "FixedRankMatrices(3, 2, 2, ℂ)"
@@ -51,6 +53,7 @@ include("utils.jl")
             SVDMPoint([1.0 0.0; 0.0 0.0], 2),
             true,
         )
+        @test is_manifold_point(M2, x2)
 
         @test !is_tangent_vector(
             M,

--- a/test/fixed_rank.jl
+++ b/test/fixed_rank.jl
@@ -5,7 +5,7 @@ include("utils.jl")
     M2 = FixedRankMatrices(3, 2, 1)
     Mc = FixedRankMatrices(3, 2, 2, ℂ)
     x = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0])
-    x2 = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0],1)
+    x2 = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0], 1)
     v = UMVTVector([0.0 0.0; 0.0 0.0; 1.0 1.0], [1.0 0.0; 0.0 1.0], zeros(2, 2))
     @test repr(M) == "FixedRankMatrices(3, 2, 2, ℝ)"
     @test repr(Mc) == "FixedRankMatrices(3, 2, 2, ℂ)"


### PR DESCRIPTION
Hi,
I think there's a small bug in the `check_manifold_point` method for `FixedRankMatrices`. I think these simple changes are enough to fit the manifold definition exactly

The error can be retrieved by doing
```julia
M = FixedRankMatrices{5, 6, 3, ℝ}()
x = SVDMPoint(rand(5, 6), 3)
check_manifold_point(M, x)
```
