### PR TITLE
Switch to docdeploy action v1

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: 1.4
-      - uses: julia-actions/julia-docdeploy@releases/v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Apparently the releases/v1 branch of docdeploy is outdated. I'm also hoping this resolves the errors we're getting for that action.