### PR TITLE
Caley Retraction

### DIFF
--- a/docs/src/manifolds/stiefel.md
+++ b/docs/src/manifolds/stiefel.md
@@ -7,19 +7,3 @@ Order = [:type, :function]
 ```
 
 ## Literature
-
-````@raw html
-<ul>
-<li id="SatoTawi2013">
-H. Sato and T. Iawi, “A complex singular value decomposition algorithm based on
-the Riemannian Newton method”, in: <emph>IEEE 52nd Annual Conference on Decision and
-Control (CDC)</emph>, 2013, p. 2972--2978,
-doi: <a href="https://doi.org/10.1109/CDC.2013.6760335">10.1109/CDC.2013.6760335</a>
-</li>
-<li>
-H. Sato: “Riemannian conjugate gradient method for complex singular value
-decomposition problem”, in: <emph>IEEE 53rd Annual COnference on Decision and Control
-(CDC)</emph>, 2014, p. 5849–5854,
-doi: <a href="https://doi.org/10.1109/CDC.2014.7040305">10.1109/CDC.2014.7040305</a>
-</li>
-````

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -277,7 +277,8 @@ export GraphManifold, GraphManifoldType, VertexManifold, EdgeManifold
 export ProjectedPointDistribution, ProductRepr, TangentBundle, TangentBundleFibers
 export TangentSpace, TangentSpaceAtPoint, VectorSpaceAtPoint, VectorSpaceType, VectorBundle
 export VectorBundleFibers
-export AbstractVectorTransportMethod, ParallelTransport, ProjectedPointDistribution
+export AbstractVectorTransportMethod,
+    CaleyVectorTransport, ParallelTransport, ProjectedPointDistribution
 export PoleLadderTransport, SchildsLadderTransport
 export PowerVectorTransport, ProductVectorTransport
 export AbstractEmbeddedManifold
@@ -297,11 +298,13 @@ export AbstractEmbeddingType, AbstractIsometricEmbeddingType
 export DefaultEmbeddingType, DefaultIsometricEmbeddingType, TransparentIsometricEmbedding
 export AbstractVectorTransportMethod, ParallelTransport, ProjectionTransport
 export AbstractRetractionMethod,
+    CaleyRetraction,
     ExponentialRetraction,
     QRRetraction,
     PolarRetraction,
     ProjectionRetraction,
     SoftmaxRetraction,
+    PadeRetraction,
     ProductRetraction,
     PowerRetraction
 export AbstractInverseRetractionMethod,

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -36,23 +36,24 @@ struct Stiefel{n,k,𝔽} <: AbstractEmbeddedManifold{𝔽,DefaultIsometricEmbedd
 Stiefel(n::Int, k::Int, field::AbstractNumbers = ℝ) = Stiefel{n,k,field}()
 
 @doc raw"""
-    PadéRetraction{m} <: AbstractRetractionMethod
+    PadeRetraction{m} <: AbstractRetractionMethod
 
 A retraction based on the Padé approximation of order $m$
 """
-struct PadéRetraction{m} <: AbstractRetractionMethod end
+struct PadeRetraction{m} <: AbstractRetractionMethod end
 
-function PadéRetraction(m::Int)
-    (m < 1) && error("The Padé based retraction is only available for positive orders, not for order $m.")
-    return PadéRetraction{m}()
+function PadeRetraction(m::Int)
+    (m < 1) &&
+        error("The Padé based retraction is only available for positive orders, not for order $m.")
+    return PadeRetraction{m}()
 end
 @doc raw"""
     CaleyRetraction <: AbstractRetractionMethod
 
-A retraction based on the Caley transform, which is realized by calling the
-[`PadéRetraction`](@ref)`{1}`.
+A retraction based on the Caley transform, which is realized by using the
+[`PadeRetraction`](@ref)`{1}`.
 """
-const CaleyRetraction = PadéRetraction{1}
+const CaleyRetraction = PadeRetraction{1}
 
 """
     CaleyVectorTransport <: AbstractVectorTransportMethod
@@ -61,7 +62,7 @@ A vector transport that one obtains by differentiating a [`CaleyRetraction`](@re
 """
 struct CaleyVectorTransport <: AbstractVectorTransportMethod end
 
-function allocation_promotion_function(M::Stiefel{n,k,ℂ}, f, args::Tuple) where {n,k}
+function allocation_promotion_function(::Stiefel{n,k,ℂ}, ::Any, ::Tuple) where {n,k}
     return complex
 end
 
@@ -278,55 +279,21 @@ function project!(::Stiefel, Y, p, X)
 end
 
 @doc raw"""
-    retract(M::Stiefel, p, X, ::PadéRetraction{m})
-
-Compute the retraction on the [`Stiefel`](@ref) manifold `M` based on the Padé approximation of order $m$[^ZhuDuan2018].
-Let $p_m$ and $q_m$ be defined for any matrix $A ∈ ℝ^{n×x}$ as
-\begin{equation*}
-  p_m(A) = \sum_{k=0}^m \frac{2m-k)!m!}{(2m)!(m-k)!}\frac{A^k}{k!}
-\end{equation*}
-and
-\begin{equation*}
-  q_m(A) = \sum_{k=0}^m \frac{2m-k)!m!}{(2m)!(m-k)!}\frac{(-A)^k}{k!}
-\end{equation*}
-respectively. Then the Padé approximation (of the matrix exponential $\exp(A)$) reads
-\begin{equation*}
-  r_m(A) = q_m(A)^{-1}p_m(A)
-\end{equation*}
-Defining further
-\begin{equation*}
-  W_{p,X} = \operatorname{P}_pXp^mathrm{H} - pX^{\mathrm{H}}\operatorname{P_p}
-  \quad\text{where} 
-  \operatorname{P}_p = I - \frac{1}{2}pp^\mathrm{H}
-\end{equation*}
-the retraction reads
-\begin{equation*}
-  \operatorname{retr}_p(X) = r_m(W_{p,X})p
-\end{equation*}
-[^ZhuDuan2018]:
-    > X. Zhu, C. Duan:
-    > On matrix exponentials and their approximations related to optimization on the Stiefel manifold,
-    > Optimizazion Letters 13(5), pp. 1069–1083, 2018.
-    > doi [10.1007/s11590-018-1341-z](https://doi.org/10.1007/s11590-018-1341-z).
-"""
-retract(::Stiefel, ::Any, ::Any, ::PadéRetraction{m}) where {m}
-
-@doc raw"""
     retract(::Stiefel, p, X, ::CaleyRetraction)
 
 Compute the retraction on the [`Stiefel`](@ref) that is based on the Caley transform[^Zhu2016].
 Using
-\begin{equation*}
-  W_{p,X} = \operatorname{P}_pXp^mathrm{H} - pX^{\mathrm{H}}\operatorname{P_p}
+````math
+  W_{p,X} = \operatorname{P}_pXp^{\mathrm{H}} - pX^{\mathrm{H}}\operatorname{P_p}
   \quad\text{where} 
-  \operatorname{P}_p = I - \frac{1}{2}pp^\mathrm{H}
-\end{equation*}
+  \operatorname{P}_p = I - \frac{1}{2}pp^{\mathrm{H}}
+````
 the formula reads
-\begin{equation*}
-    \operatorname{retr}_p(X) = \Bigl(I - \frac{1}{2}W_{p,X}\Bigr)^{-1}\Bigl(I + \frac{1}{2}W_{p,X}\Bigr)p.
-\end{equation*}
+````math
+    \operatorname{retr}_pX = \Bigl(I - \frac{1}{2}W_{p,X}\Bigr)^{-1}\Bigl(I + \frac{1}{2}W_{p,X}\Bigr)p.
+````
 
-It is implemented as the case $m=1$ of the [`PadéRetraction`](@ref).
+It is implemented as the case $m=1$ of the [`PadeRetraction`](@ref).
 
 [^Zhu2016]:
     > X. Zhu:
@@ -335,6 +302,40 @@ It is implemented as the case $m=1$ of the [`PadéRetraction`](@ref).
     > doi [10.1007/s10589-016-9883-4](https://doi.org/10.1007/s10589-016-9883-4).
 """
 retract(::Stiefel, ::Any, ::Any, ::CaleyRetraction)
+
+@doc raw"""
+    retract(M::Stiefel, p, X, ::PadeRetraction{m}) where {m}
+
+Compute the retraction on the [`Stiefel`](@ref) manifold `M` based on the Padé approximation of order $m$[^ZhuDuan2018].
+Let $p_m$ and $q_m$ be defined for any matrix $A ∈ ℝ^{n×x}$ as
+````math
+  p_m(A) = \sum_{k=0}^m \frac{2m-k)!m!}{(2m)!(m-k)!}\frac{A^k}{k!}
+````
+and
+````math
+  q_m(A) = \sum_{k=0}^m \frac{2m-k)!m!}{(2m)!(m-k)!}\frac{(-A)^k}{k!}
+````
+respectively. Then the Padé approximation (of the matrix exponential $\exp(A)$) reads
+````math
+  r_m(A) = q_m(A)^{-1}p_m(A)
+````
+Defining further
+````math
+  W_{p,X} = \operatorname{P}_pXp^{\mathrm{H}} - pX^{\mathrm{H}}\operatorname{P_p}
+  \quad\text{where} 
+  \operatorname{P}_p = I - \frac{1}{2}pp^{\mathrm{H}}
+````
+the retraction reads
+````math
+  \operatorname{retr}_pX = r_m(W_{p,X})p
+````
+[^ZhuDuan2018]:
+    > X. Zhu, C. Duan:
+    > On matrix exponentials and their approximations related to optimization on the Stiefel manifold,
+    > Optimizazion Letters 13(5), pp. 1069–1083, 2018.
+    > doi [10.1007/s11590-018-1341-z](https://doi.org/10.1007/s11590-018-1341-z).
+"""
+retract(::Stiefel, ::Any, ::Any, ::PadeRetraction{m}) where {m}
 
 @doc raw"""
     retract(M::Stiefel, p, X, ::PolarRetraction)
@@ -349,7 +350,7 @@ Compute the SVD-based retraction [`PolarRetraction`](@ref) on the
 retract(::Stiefel, ::Any, ::Any, ::PolarRetraction)
 
 @doc raw"""
-    retract(M::Stiefel, p, X, ::QRRetraction )
+    retract(M::Stiefel, p, X, ::QRRetraction)
 
 Compute the QR-based retraction [`QRRetraction`](@ref) on the
 [`Stiefel`](@ref) manifold `M`. With $QR = p + X$ the retraction reads
@@ -372,13 +373,19 @@ where $\operatorname{sgn}(p) = \begin{cases}
 """
 retract(::Stiefel, ::Any, ::Any, ::QRRetraction)
 
-function retract!(::Stiefel, q, p, X, ::PadéRetraction{m}) where {m}
-    Pp = p*p'
+function retract!(::Stiefel, q, p, X, ::PadeRetraction{m}) where {m}
+    Pp = p * p'
     Pp .= one(Pp) - Pp
-    WpX = Pp*X*p' - p*X'*Pp
-    pm = sum( [factorial(2m-k)*factorial(m) / (factorial(2m)*factorial(m-k)Ü*factorial(k)) * WpX^k for k=0:m])
-    qm = sum( [factorial(2m-k)*factorial(m) / (factorial(2m)*factorial(m-k)Ü*factorial(k)) * (-WpX)^k for k=0:m])
-    copyto!(q, (qm\pm) * p)
+    WpX = Pp * X * p' - p * X' * Pp
+    pm = sum([
+        factorial(2m - k) * factorial(m) /
+        (factorial(2m) * factorial(m - k)Ü * factorial(k)) * WpX^k for k in 0:m
+    ])
+    qm = sum([
+        factorial(2m - k) * factorial(m) /
+        (factorial(2m) * factorial(m - k)Ü * factorial(k)) * (-WpX)^k for k in 0:m
+    ])
+    return copyto!(q, (qm \ pm) * p)
 end
 function retract!(::Stiefel, q, p, X, ::PolarRetraction)
     s = svd(p + X)
@@ -397,26 +404,26 @@ end
 Compute the vector transport given by the differentiated retraction of the [`CaleyRetraction`](@ref), cf. [^Zhu2016] Equation (17).
 
 The formula reads
-\begin{equation*}
+````math
 \operatorname{T}_{d}(X) =
 \Bigl(I - \frac{1}{2}W_{p,d}\Bigr)^{-1}W_{p,X}\Bigl(I - \frac{1}{2}W_{p,d}\Bigr)^{-1}p,
-\end{equation*}
+````
 with
-\begin{equation*}
-  W_{p,X} = \operatorname{P}_pXp^mathrm{H} - pX^{\mathrm{H}}\operatorname{P_p}
+````math
+  W_{p,X} = \operatorname{P}_pXp^{\mathrm{H}} - pX^{\mathrm{H}}\operatorname{P_p}
   \quad\text{where} 
-  \operatorname{P}_p = I - \frac{1}{2}pp^\mathrm{H}.
-\end{equation*}
+  \operatorname{P}_p = I - \frac{1}{2}pp^{\mathrm{H}}
+````
 """
 vector_transport_to(::Stiefel, p, X, d, ::CaleyVectorTransport)
 
 function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTransport)
-    Pp = p*p'
+    Pp = p * p'
     Pp .= one(Pp) - Pp
-    Wpd = Pp*d*p' - p*d'*Pp
-    WpX = Pp*Y*p' - p*Y'*Pp
-    q1 = one(Wpd - 1//2 * Wpd)
-    copyto!(Y, (q1\WpX) * (q1\p))
+    Wpd = Pp * d * p' - p * d' * Pp
+    WpX = Pp * Y * p' - p * Y' * Pp
+    q1 = one(Wpd - 1 // 2 * Wpd)
+    return copyto!(Y, (q1 \ WpX) * (q1 \ p))
 end
 
 @doc raw"""
@@ -427,7 +434,7 @@ i.e. `(n,k)`, which is the matrix dimensions.
 """
 @generated representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
 
-Base.show(io::IO, ::PadéRetraction{m}) where {m} = print(io, "PadéRetraction($(m))")
+Base.show(io::IO, ::PadeRetraction{m}) where {m} = print(io, "PadeRetraction($(m))")
 
 Base.show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(F))")
 

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -374,7 +374,7 @@ where $\operatorname{sgn}(p) = \begin{cases}
 retract(::Stiefel, ::Any, ::Any, ::QRRetraction)
 
 function retract!(::Stiefel, q, p, X, ::PadeRetraction{m}) where {m}
-    Pp = I - p * p'
+    Pp = I - 1 // 2 * p * p'
     WpX = Pp * X * p' - p * X' * Pp
     pm = sum([
         factorial(2m - k) * factorial(m) /
@@ -420,7 +420,7 @@ tangent space at $q=\operatorname{retr}_p(d)$ using the [`CaleyRetraction`](@ref
 vector_transport_direction(M::Stiefel, p, X, d, ::CaleyVectorTransport)
 
 function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTransport)
-    Pp = I - p * p'
+    Pp = I - 1 // 2 * p * p'
     Wpd = Pp * d * p' - p * d' * Pp
     WpX = Pp * X * p' - p * X' * Pp
     q1 = one(Wpd) - 1 // 2 * Wpd

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -81,7 +81,7 @@ function check_manifold_point(M::Stiefel{n,k,𝔽}, p; kwargs...) where {n,k,�
     if !isapprox(c, one(c); kwargs...)
         return DomainError(
             norm(c - one(c)),
-            "The point $(p) does not lie on $(M), because x'x is not the unit matrix.",
+            "The point $(p) does not lie on $(M), because p'p is not the unit matrix.",
         )
     end
     return nothing
@@ -121,7 +121,7 @@ function check_tangent_vector(
     if !isapprox(p' * X, -conj(X' * p); kwargs...)
         return DomainError(
             norm(p' * X + conj(X' * p)),
-            "The matrix $(X) is does not lie in the tangent space of $(p) on the Stiefel manifold of dimension ($(n),$(k)), since x'v + v'x is not the zero matrix.",
+            "The matrix $(X) is does not lie in the tangent space of $(p) on the Stiefel manifold of dimension ($(n),$(k)), since p'X + X'p is not the zero matrix.",
         )
     end
     return nothing
@@ -379,11 +379,11 @@ function retract!(::Stiefel, q, p, X, ::PadeRetraction{m}) where {m}
     WpX = Pp * X * p' - p * X' * Pp
     pm = sum([
         factorial(2m - k) * factorial(m) /
-        (factorial(2m) * factorial(m - k)Ü * factorial(k)) * WpX^k for k in 0:m
+        (factorial(2m) * factorial(m - k) * factorial(k)) * WpX^k for k in 0:m
     ])
     qm = sum([
         factorial(2m - k) * factorial(m) /
-        (factorial(2m) * factorial(m - k)Ü * factorial(k)) * (-WpX)^k for k in 0:m
+        (factorial(2m) * factorial(m - k) * factorial(k)) * (-WpX)^k for k in 0:m
     ])
     return copyto!(q, (qm \ pm) * p)
 end
@@ -419,10 +419,10 @@ vector_transport_to(::Stiefel, p, X, d, ::CaleyVectorTransport)
 
 function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTransport)
     Pp = p * p'
-    Pp .= one(Pp) - Pp
+    Pp .= one(Pp) - 1 // 2 * Pp
     Wpd = Pp * d * p' - p * d' * Pp
-    WpX = Pp * Y * p' - p * Y' * Pp
-    q1 = one(Wpd - 1 // 2 * Wpd)
+    WpX = Pp * X * p' - p * X' * Pp
+    q1 = one(Wpd) - 1 // 2 * Wpd
     return copyto!(Y, (q1 \ WpX) * (q1 \ p))
 end
 
@@ -434,8 +434,8 @@ i.e. `(n,k)`, which is the matrix dimensions.
 """
 @generated representation_size(::Stiefel{n,k}) where {n,k} = (n, k)
 
+Base.show(io::IO, ::CaleyRetraction) = print(io, "CaleyRetraction()")
 Base.show(io::IO, ::PadeRetraction{m}) where {m} = print(io, "PadeRetraction($(m))")
-
 Base.show(io::IO, ::Stiefel{n,k,F}) where {n,k,F} = print(io, "Stiefel($(n), $(k), $(F))")
 
 """

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -304,7 +304,7 @@ It is implemented as the case $m=1$ of the [`PadeRetraction`](@ref).
 retract(::Stiefel, ::Any, ::Any, ::CaleyRetraction)
 
 @doc raw"""
-    retract(M::Stiefel, p, X, ::PadeRetraction{m}) where {m}
+    retract(M::Stiefel, p, X, ::PadeRetraction{m})
 
 Compute the retraction on the [`Stiefel`](@ref) manifold `M` based on the Padé approximation of order $m$[^ZhuDuan2018].
 Let $p_m$ and $q_m$ be defined for any matrix $A ∈ ℝ^{n×x}$ as
@@ -335,7 +335,7 @@ the retraction reads
     > Optimizazion Letters 13(5), pp. 1069–1083, 2018.
     > doi [10.1007/s11590-018-1341-z](https://doi.org/10.1007/s11590-018-1341-z).
 """
-retract(::Stiefel, ::Any, ::Any, ::PadeRetraction{m}) where {m}
+retract(::Stiefel, ::Any, ::Any, ::PadeRetraction)
 
 @doc raw"""
     retract(M::Stiefel, p, X, ::PolarRetraction)

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -423,7 +423,7 @@ function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTranspo
     Pp = I - 1 // 2 * p * p'
     Wpd = Pp * d * p' - p * d' * Pp
     WpX = Pp * X * p' - p * X' * Pp
-    q1 = one(Wpd) - 1 // 2 * Wpd
+    q1 = I - 1 // 2 * Wpd
     return copyto!(Y, (q1 \ WpX) * (q1 \ p))
 end
 

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -415,7 +415,7 @@ with
   \operatorname{P}_p = I - \frac{1}{2}pp^{\mathrm{H}}
 ````
 """
-vector_transport_to(::Stiefel, p, X, d, ::CaleyVectorTransport)
+vector_transport_direction(M::Stiefel, p, X, d, ::CaleyVectorTransport)
 
 function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTransport)
     Pp = p * p'

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -414,6 +414,9 @@ with
   \quad\text{where} 
   \operatorname{P}_p = I - \frac{1}{2}pp^{\mathrm{H}}
 ````
+
+Since this is the differentiated retraction as a vector transport, the result will be in the
+tangent space at $q=\operatorname{retr}_p(d)$ using the [`CaleyRetraction`](@ref).
 """
 vector_transport_direction(M::Stiefel, p, X, d, ::CaleyVectorTransport)
 

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -374,8 +374,7 @@ where $\operatorname{sgn}(p) = \begin{cases}
 retract(::Stiefel, ::Any, ::Any, ::QRRetraction)
 
 function retract!(::Stiefel, q, p, X, ::PadeRetraction{m}) where {m}
-    Pp = p * p'
-    Pp .= one(Pp) - Pp
+    Pp = I - p * p'
     WpX = Pp * X * p' - p * X' * Pp
     pm = sum([
         factorial(2m - k) * factorial(m) /
@@ -421,8 +420,7 @@ tangent space at $q=\operatorname{retr}_p(d)$ using the [`CaleyRetraction`](@ref
 vector_transport_direction(M::Stiefel, p, X, d, ::CaleyVectorTransport)
 
 function vector_transport_direction!(::Stiefel, Y, p, X, d, ::CaleyVectorTransport)
-    Pp = p * p'
-    Pp .= one(Pp) - 1 // 2 * Pp
+    Pp = I - p * p'
     Wpd = Pp * d * p' - p * d' * Pp
     WpX = Pp * X * p' - p * X' * Pp
     q1 = one(Wpd) - 1 // 2 * Wpd

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -379,14 +379,14 @@ function retract!(::Stiefel, q, p, X, ::PadeRetraction{m}) where {m}
     pm = zeros(size(WpX))
     qm = zeros(size(WpX))
     WpXk = similar(WpX)
-    copyto!(WpXk, factorial(m) / factorial(2*m) * I) # factorial factor independent of k
-    for k ∈ 0:m
+    copyto!(WpXk, factorial(m) / factorial(2 * m) * I) # factorial factor independent of k
+    for k in 0:m
         # incrementally build (2m-k)!/(m-k)!(k)! for k > 0, i.e.
         # remove factor (2m-k+1) in the nominator, (m-k+1) in the denominator and multiply by 1/k
-        WpXk .*= ( k==0 ? 2 : (m-k+1)/( (2*m-k+1) * k) )
+        WpXk .*= (k == 0 ? 2 : (m - k + 1) / ((2 * m - k + 1) * k))
         pm .+= WpXk
-        if k%2 == 0
-            qm .+=WpXk
+        if k % 2 == 0
+            qm .+= WpXk
         else
             qm .-= WpXk
         end

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -177,7 +177,7 @@ include("utils.jl")
         end
     end
 
-    @testset "Padé & Caley retractions" begin
+    @testset "Padé & Caley retractions and Caley based transport" begin
         M = Stiefel(3, 2)
         p = [1.0 0.0; 0.0 1.0; 0.0 0.0]
         X = [0.0 0.0; 0.0 0.0; 1.0 1.0]
@@ -186,7 +186,8 @@ include("utils.jl")
         @test repr(r1) == "CaleyRetraction()"
         q1 = retract(M, p, X, r1)
         @test is_manifold_point(M, q1)
-        @test is_tangent_vector(M, q1, Y)
+        Y = vector_transport_direction(M, p, X, X, CaleyVectorTransport())
+        @test is_tangent_vector(M, q1, Y; atol = 10^-15)
         r2 = PadeRetraction(2)
         @test repr(r2) == "PadeRetraction(2)"
         q2 = retract(M, p, X, r2)

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -176,4 +176,20 @@ include("utils.jl")
             @test manifold_dimension(M) == 18
         end
     end
+
+    @testset "Padé & Caley retractions" begin
+        M = Stiefel(3, 2)
+        p = [1.0 0.0; 0.0 1.0; 0.0 0.0]
+        X = [0.0 0.0; 0.0 0.0; 1.0 1.0]
+        r1 = CaleyRetraction()
+        @test r1 == PadeRetraction(1)
+        @test repr(r1) == "CaleyRetraction()"
+        q1 = retract(M, p, X, r1)
+        @test is_manifold_point(M, q1)
+        @test is_tangent_vector(M, q1, Y)
+        r2 = PadeRetraction(2)
+        @test repr(r2) == "PadeRetraction(2)"
+        q2 = retract(M, p, X, r2)
+        @test is_manifold_point(M, q2)
+    end
 end


### PR DESCRIPTION
adds a pade approximation based retraction as well as its special case the caley retraction – as well as a corresponding vector transport.

We could check whether a `VectorTransport` that stems from a retraction (its differentiation) is a reasonable own type.

* [x] Tests
* [x] Check documentation.