### PR TITLE
CompatHelper: bump compat for "Distributions" to "0.24"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distributions = "0.22.6, 0.23"
+Distributions = "0.22.6, 0.23, 0.24"
 Einsum = "0.4"
 FiniteDiff = "2"
 FiniteDifferences = "0.9, 0.10"


### PR DESCRIPTION
This pull request changes the compat entry for the `Distributions` package from `0.22.6, 0.23` to `0.22.6, 0.23, 0.24`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.