### PR TITLE
Move formatter config to configuration file

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,6 @@
+short_to_long_function_def = true
+always_for_in = true
+whitespace_ops_in_indices = true
+pipe_to_function_call = true
+import_to_using = true
+always_use_return = true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,15 +17,7 @@ jobs:
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(
-              ".",
-              short_to_long_function_def = true,
-              always_for_in = true,
-              whitespace_ops_in_indices = true,
-              pipe_to_function_call = true,
-              import_to_using = true,
-              always_use_return = true,
-          )'
+          julia  -e 'using JuliaFormatter; format(".")'
       - name: Check format
         run: |
           julia -e '


### PR DESCRIPTION
This also makes running formatter locally easier because you don't have to pass the style anymore.

If this is ok, I would also apply this change to our other packages (just doing one commit to master).