### PR TITLE
Fixes Nested PowerManifold of a PowerManifold to not concatenate sizes.

### DIFF
--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -445,7 +445,7 @@ function get_coordinates!(M::AbstractPowerManifold, Y, p, X, B::DefaultOrthonorm
         # TODO: this view is really suboptimal when `dim` can be statically determined
         get_coordinates!(
             M.manifold,
-            view(Y, v_iter:(v_iter+dim-1)),
+            view(Y, v_iter:(v_iter + dim - 1)),
             _read(M, rep_size, p, i),
             _read(M, rep_size, X, i),
             B,
@@ -467,7 +467,7 @@ function get_coordinates!(
     for i in get_iterator(M)
         get_coordinates!(
             M.manifold,
-            view(Y, v_iter:(v_iter+dim-1)),
+            view(Y, v_iter:(v_iter + dim - 1)),
             _read(M, rep_size, p, i),
             _read(M, rep_size, X, i),
             _access_nested(B.data.bases, i),
@@ -500,7 +500,7 @@ function get_vector!(
             M.manifold,
             _write(M, rep_size, Y, i),
             _read(M, rep_size, p, i),
-            X[v_iter:(v_iter+dim-1)],
+            X[v_iter:(v_iter + dim - 1)],
             _access_nested(B.data.bases, i),
         )
         v_iter += dim
@@ -516,7 +516,7 @@ function get_vector!(M::AbstractPowerManifold, Y, p, X, B::DefaultOrthonormalBas
             M.manifold,
             _write(M, rep_size, Y, i),
             _read(M, rep_size, p, i),
-            X[v_iter:(v_iter+dim-1)],
+            X[v_iter:(v_iter + dim - 1)],
             B,
         )
         v_iter += dim

--- a/test/power_manifold.jl
+++ b/test/power_manifold.jl
@@ -15,6 +15,10 @@ Random.seed!(42)
     Ms2 = PowerManifold(Ms, 5, 7)
     @test power_dimensions(Ms2) == (5, 7)
     @test manifold_dimension(Ms2) == 70
+    Ms2n = PowerManifold(Ms1, NestedPowerRepresentation(), 7)
+    @test power_dimensions(Ms2n) == (7,)
+    @test manifold_dimension(Ms2n) == 70
+
     Mr = Manifolds.Rotations(3)
     Mr1 = PowerManifold(Mr, 5)
     Mrn1 = PowerManifold(Mr, Manifolds.NestedPowerRepresentation(), 5)


### PR DESCRIPTION
This case was not documented that way, so to be precise this might be a breaking PR (comments welcome). This fixes the following situation:

Imagine you have a `N = PowerManifold(M,n)` (maybe nested, but not required to be)
and you form a `O = PowerManifold(N, NestedPowerRepresentation(), m)`

I would expect that the nested-ness of `O` specifies, that elements are vectors of length `m` (or arrays if `m` is not a number but a tuple), since we assume nestedness.
Previously this was not the case an `O` would be a `PowerManifold(M,n,m)`, which one would not expect.

Now this is documented to work as described above, using a new constructor and its test is also added.

