### PR TITLE
Vector space manifold

### DIFF
--- a/docs/src/manifolds/vector_bundle.md
+++ b/docs/src/manifolds/vector_bundle.md
@@ -14,6 +14,7 @@ The important difference between functions operating on `VectorBundle` and `Vect
 `VectorBundleFibers` refers to the whole set of fibers of a vector bundle.
 There is also another type, [`VectorSpaceAtPoint`](@ref), that represents a specific fiber at a given point.
 This distinction is made to reduce the need to repeatedly construct objects of type [`VectorSpaceAtPoint`](@ref) in certain usage scenarios.
+This is also considered a manifold.
 
 ## FVector
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -497,22 +497,10 @@ function get_vector!(
     )
     return Y
 end
-function get_vector!(
-    M::TangentBundleFibers,
-    Y,
-    p,
-    X,
-    B::ManifoldsBase.all_uncached_bases,
-)
+function get_vector!(M::TangentBundleFibers, Y, p, X, B::ManifoldsBase.all_uncached_bases)
     return get_vector!(M.manifold, Y, p, X, B)
 end
-function get_vector!(
-    M::TangentSpaceAtPoint,
-    Y,
-    p,
-    X,
-    B::ManifoldsBase.all_uncached_bases,
-)
+function get_vector!(M::TangentSpaceAtPoint, Y, p, X, B::ManifoldsBase.all_uncached_bases)
     return get_vector!(M.fiber.manifold, Y, M.point, X, B)
 end
 

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -261,6 +261,15 @@ function distance(B::VectorBundle, p, q)
     dist_vec = distance(B.fiber, xp, Vp, vy_x)
     return sqrt(dist_man^2 + dist_vec^2)
 end
+"""
+    distance(M::TangentSpaceAtPoint, p, q)
+
+Distance between vectors `p` and `q` from the vector space `M`. It is calculated as the norm
+of their difference.
+"""
+function distance(M::TangentSpaceAtPoint, p, q)
+    return norm(M.fiber.manifold, M.point, q - p)
+end
 
 function number_eltype(::Type{FVector{TType,TData}}) where {TType<:VectorSpaceType,TData}
     return number_eltype(TData)
@@ -289,7 +298,15 @@ where $V_{\exp}$ is the result of vector transport of $V_p + V_{X,F}$
 to the point $\exp_{x_p}(V_{X,M})$.
 The sum $V_p + V_{X,F}$ corresponds to the exponential map in the vector space $F$.
 """
-exp(::VectorBundle, ::Any)
+exp(::VectorBundle, ::Any, ::Any)
+
+@doc raw"""
+    exp(M::TangentSpaceAtPoint, p, X)
+
+Exponential map of tangent vectors `X` and `p` from the tangent space `M`. It is
+calculated as their sum.
+"""
+exp(::TangentSpaceAtPoint, ::Any, ::Any)
 
 function exp!(B::VectorBundle, q, p, X)
     xp, Xp = submanifold_components(B.manifold, p)
@@ -297,6 +314,10 @@ function exp!(B::VectorBundle, q, p, X)
     VXM, VXF = submanifold_components(B.manifold, X)
     exp!(B.manifold, xq, xp, VXM)
     vector_transport_to!(B.manifold, Xq, xp, Xp + VXF, xq, B.vector_transport.method_point)
+    return q
+end
+function exp!(M::TangentSpaceAtPoint, q, p, X)
+    copyto!(q, p + X)
     return q
 end
 
@@ -357,9 +378,15 @@ for BT in [
     eval(quote
         @invoke_maker 3 AbstractBasis get_basis(M::VectorBundle, p, B::$BT)
     end)
+    eval(quote
+        @invoke_maker 3 AbstractBasis get_basis(M::TangentSpaceAtPoint, p, B::$BT)
+    end)
 end
 function get_basis(M::TangentBundleFibers, p, B::AbstractBasis)
     return get_basis(M.manifold, p, B)
+end
+function get_basis(M::TangentSpaceAtPoint, p, B::AbstractBasis)
+    return get_basis(M.fiber.manifold, M.point, B)
 end
 
 function get_coordinates!(M::VectorBundle, Y, p, X, B::AbstractBasis)
@@ -403,6 +430,17 @@ for BT in [
             )
         end,
     )
+    eval(
+        quote
+            @invoke_maker 5 AbstractBasis get_coordinates!(
+                M::TangentSpaceAtPoint,
+                Y,
+                p,
+                X,
+                B::$BT,
+            )
+        end,
+    )
 end
 function get_coordinates!(M::VectorBundle, Y, p, X, B::CachedBasis)
     return error("get_coordinates! called on $M with an incorrect CachedBasis. Expected a CachedBasis with VectorBundleBasisData, given $B")
@@ -414,8 +452,17 @@ function get_coordinates!(
     p,
     X,
     B::ManifoldsBase.all_uncached_bases,
-) where {N}
+)
     return get_coordinates!(M.manifold, Y, p, X, B)
+end
+function get_coordinates!(
+    M::TangentSpaceAtPoint,
+    Y,
+    p,
+    X,
+    B::ManifoldsBase.all_uncached_bases,
+)
+    return get_coordinates!(M.fiber.manifold, Y, M.point, X, B)
 end
 
 function get_vector!(M::VectorBundle, Y, p, X, B::DefaultOrthonormalBasis)
@@ -456,8 +503,17 @@ function get_vector!(
     p,
     X,
     B::ManifoldsBase.all_uncached_bases,
-) where {N}
+)
     return get_vector!(M.manifold, Y, p, X, B)
+end
+function get_vector!(
+    M::TangentSpaceAtPoint,
+    Y,
+    p,
+    X,
+    B::ManifoldsBase.all_uncached_bases,
+)
+    return get_vector!(M.fiber.manifold, Y, M.point, X, B)
 end
 
 function get_vectors(
@@ -481,7 +537,18 @@ end
 function get_vectors(M::VectorBundleFibers, p, B::CachedBasis)
     return get_vectors(M.manifold, p, B)
 end
+function get_vectors(M::TangentSpaceAtPoint, p, B::CachedBasis)
+    return get_vectors(M.fiber.manifold, M.point, B)
+end
+
 Base.@propagate_inbounds Base.getindex(x::FVector, i) = getindex(x.data, i)
+
+@doc raw"""
+    injectivity_radius(M::TangentSpaceAtPoint)
+
+Return the injectivity radius on the [`TangentSpaceAtPoint`](@ref) `M`, which is $∞$.
+"""
+injectivity_radius(::TangentSpaceAtPoint) = Inf
 
 """
     inner(B::VectorBundleFibers, p, X, Y)
@@ -530,6 +597,14 @@ function inner(B::VectorBundle, p, X, Y)
     VYM, VYF = submanifold_components(B.manifold, Y)
     return inner(B.manifold, px, VXM, VYM) + inner(B.fiber, Vx, VXF, VYF)
 end
+"""
+    inner(M::TangentSpaceAtPoint, p, X, Y)
+
+Inner product of vectors `X` and `Y` from the tangent space at `M`.
+"""
+function inner(M::TangentSpaceAtPoint, p, X, Y)
+    return inner(M.fiber.manifold, M.point, X, Y)
+end
 
 function Base.isapprox(B::VectorBundle, p, q; kwargs...)
     xp, Vp = submanifold_components(B.manifold, p)
@@ -544,8 +619,8 @@ function Base.isapprox(B::VectorBundle, p, X, Y; kwargs...)
     return isapprox(B.manifold, VXM, VYM; kwargs...) &&
            isapprox(VectorSpaceAtPoint(B.fiber, px), VXF, VYF; kwargs...)
 end
-function Base.isapprox(B::TangentSpaceAtPoint, X, Y; kwargs...)
-    return isapprox(B.fiber.manifold, B.point, X, Y; kwargs...)
+function Base.isapprox(M::TangentSpaceAtPoint, X, Y; kwargs...)
+    return isapprox(M.fiber.manifold, M.point, X, Y; kwargs...)
 end
 
 @doc raw"""
@@ -568,6 +643,13 @@ where $V_{\log}$ is the result of vector transport of $V_q$ to the point $x_p$.
 The difference $V_{\log} - V_p$ corresponds to the logarithmic map in the vector space $F$.
 """
 log(::VectorBundle, ::Any...)
+"""
+    log(M::TangentSpaceAtPoint, p, q)
+
+Logarithmic map on the tangent space manifold `M`, calculated as the difference of tangent
+vectors `q` and `p` from `M`.
+"""
+log(::TangentSpaceAtPoint, ::Any...)
 
 function log!(B::VectorBundle, X, p, q)
     px, Vx = submanifold_components(B.manifold, p)
@@ -578,9 +660,16 @@ function log!(B::VectorBundle, X, p, q)
     copyto!(VXF, VXF - Vx)
     return X
 end
+function log!(M::TangentSpaceAtPoint, X, p, q)
+    copyto!(X, q - p)
+    return X
+end
 
 function manifold_dimension(B::VectorBundle)
     return manifold_dimension(B.manifold) + vector_space_dimension(B.fiber)
+end
+function manifold_dimension(M::VectorSpaceAtPoint)
+    return vector_space_dimension(M.fiber)
 end
 
 """
@@ -591,6 +680,7 @@ at point `p` from manifold `B.manifold`.
 """
 LinearAlgebra.norm(B::VectorBundleFibers, p, X) = sqrt(inner(B, p, X, X))
 LinearAlgebra.norm(B::VectorBundleFibers{<:TangentSpaceType}, p, X) = norm(B.manifold, p, X)
+LinearAlgebra.norm(M::VectorSpaceAtPoint, p, X) = norm(M.fiber.manifold, M.point, X)
 
 @doc raw"""
     project(B::VectorBundle, p)
@@ -609,12 +699,24 @@ and then projecting the vector $V_p$ to the tangent space $T_{x_p}\mathcal M$.
 """
 project(::VectorBundle, ::Any)
 
+
+@doc raw"""
+    project(M::TangentSpaceAtPoint, p)
+
+Project the point `p` from the tangent space `M`, that is project the vector `p`
+tangent at `M.point`.
+"""
+project(::TangentSpaceAtPoint, ::Any)
+
 function project!(B::VectorBundle, q, p)
     px, pVx = submanifold_components(B.manifold, p)
     qx, qVx = submanifold_components(B.manifold, q)
     project!(B.manifold, qx, px)
     project!(B.manifold, qVx, qx, pVx)
     return q
+end
+function project!(M::TangentSpaceAtPoint, q, p)
+    return project!(M.fiber.manifold, q, M.point, p)
 end
 
 @doc raw"""
@@ -636,6 +738,13 @@ The projection is calculated by projecting $V_{X,M}$ to tangent space $T_{x_p}\m
 and then projecting the vector $V_{X,F}$ to the fiber $F$.
 """
 project(::VectorBundle, ::Any, ::Any)
+@doc raw"""
+    project(M::TangentSpaceAtPoint, p, X)
+
+Project the vector `X` from the tangent space `M`, that is project the vector `X`
+tangent at `M.point`.
+"""
+project(::TangentSpaceAtPoint, ::Any, ::Any)
 
 function project!(B::VectorBundle, Y, p, X)
     px, Vx = submanifold_components(B.manifold, p)
@@ -644,6 +753,9 @@ function project!(B::VectorBundle, Y, p, X)
     project!(B.manifold, VYM, px, VXM)
     project!(B.manifold, VYF, px, VXF)
     return Y
+end
+function project!(M::TangentSpaceAtPoint, Y, p, X)
+    return project!(M.fiber.manifold, Y, M.point, X)
 end
 
 """
@@ -672,6 +784,9 @@ function representation_size(B::VectorBundle)
     len_manifold = prod(representation_size(B.manifold))
     len_vs = prod(representation_size(B.fiber))
     return (len_manifold + len_vs,)
+end
+function representation_size(B::TangentSpaceAtPoint)
+    return representation_size(B.fiber.manifold)
 end
 
 @doc raw"""
@@ -838,6 +953,12 @@ function vector_transport_to!(M::VectorBundle, Y, p, X, q, m::VectorBundleVector
     vector_transport_to!(M.manifold, VYF, px, VXF, qx, m.method_vector)
     return Y
 end
+function vector_transport_to!(M::TangentSpaceAtPoint, Y, p, X, q)
+    return copyto!(Y, X)
+end
+function vector_transport_to!(M::TangentSpaceAtPoint, Y, p, X, q, ::ParallelTransport)
+    return copyto!(Y, X)
+end
 
 """
     zero_vector(B::VectorBundleFibers, p)
@@ -883,10 +1004,21 @@ $\mathbf{0}_F$ is the zero element of the vector space $F$.
 """
 zero_tangent_vector(::VectorBundle, ::Any...)
 
+@doc raw"""
+    zero_tangent_vector(M::TangentSpaceAtPoint, p)
+
+Zero tangent vector at point `p` from the tangent space `M`, that is the zero tangent vector
+at point `M.point`.
+"""
+zero_tangent_vector(::TangentSpaceAtPoint, ::Any...)
+
 function zero_tangent_vector!(B::VectorBundle, X, p)
     xp, Vp = submanifold_components(B.manifold, p)
     VXM, VXF = submanifold_components(B.manifold, X)
     zero_tangent_vector!(B.manifold, VXM, xp)
     zero_vector!(B.fiber, VXF, Vp)
     return X
+end
+function zero_tangent_vector!(M::TangentSpaceAtPoint, X, p)
+    return zero_tangent_vector!(M.fiber.manifold, X, M.point)
 end

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -77,13 +77,17 @@ CotangentBundleFibers(M::Manifold) = VectorBundleFibers(CotangentSpace, M)
 A vector space (fiber type `fiber` of a vector bundle) at point `p` from
 the manifold `fiber.manifold`.
 """
-struct VectorSpaceAtPoint{TFiber<:VectorBundleFibers,TX}
+struct VectorSpaceAtPoint{
+    𝔽,
+    TFiber<:VectorBundleFibers{<:VectorSpaceType,<:Manifold{𝔽}},
+    TX,
+} <: Manifold{𝔽}
     fiber::TFiber
     point::TX
 end
 
 const TangentSpaceAtPoint{M} =
-    VectorSpaceAtPoint{TangentBundleFibers{M}} where {M<:Manifold}
+    VectorSpaceAtPoint{𝔽,TangentBundleFibers{M}} where {𝔽,M<:Manifold{𝔽}}
 
 """
     TangentSpaceAtPoint(M::Manifold, p)
@@ -101,7 +105,7 @@ Return a [`TangentSpaceAtPoint`](@ref) representing tangent space at `p` on the 
 TangentSpace(M::Manifold, p) = VectorSpaceAtPoint(TangentBundleFibers(M), p)
 
 const CotangentSpaceAtPoint{M} =
-    VectorSpaceAtPoint{CotangentBundleFibers{M}} where {M<:Manifold}
+    VectorSpaceAtPoint{𝔽,CotangentBundleFibers{M}} where {𝔽,M<:Manifold{𝔽}}
 
 """
     CotangentSpaceAtPoint(M::Manifold, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,7 @@ end
         @test length(Test.detect_ambiguities(Manifolds)) <= 98
         @test length(our_base_ambiguities()) <= 4
     else
-        @test length(Test.detect_ambiguities(ManifoldsBase)) <= 12
+        @test length(Test.detect_ambiguities(ManifoldsBase)) <= 17
         @test length(Test.detect_ambiguities(Manifolds)) == 0
         @test length(our_base_ambiguities()) <= 21
     end

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -57,8 +57,9 @@ struct TestVectorSpaceType <: VectorSpaceType end
     TEST_STATIC_SIZED && push!(types, MVector{3,Float64})
 
     for T in types
-        x = convert(T, [1.0, 0.0, 0.0])
+        p = convert(T, [1.0, 0.0, 0.0])
         TB = TangentBundle(M)
+        TpM = TangentSpaceAtPoint(M, p)
         @test sprint(show, TB) == "TangentBundle(Sphere(2, ℝ))"
         @test base_manifold(TB) == M
         @test manifold_dimension(TB) == 2 * manifold_dimension(M)
@@ -99,6 +100,23 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 test_project_point = true,
                 test_default_vector_transport = true,
                 basis_types_vecs = basis_types,
+                projection_atol_multiplier = 4,
+            )
+
+            # tangent space at point
+            pts_TpM = map(p -> convert(T, p), [[0.0, 0.0, 1.0], [0.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
+            test_manifold(
+                TpM,
+                pts_TpM,
+                test_injectivity_radius = true,
+                test_reverse_diff = isa(T, Vector),
+                test_forward_diff = isa(T, Vector),
+                test_tangent_vector_broadcasting = true,
+                test_vee_hat = false,
+                test_project_tangent = true,
+                test_project_point = true,
+                test_default_vector_transport = true,
+                basis_types_to_from = (DefaultOrthonormalBasis(),),
                 projection_atol_multiplier = 4,
             )
         end

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -27,6 +27,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
         @test (-fv1).type == TangentSpace
         @test isa(2 * fv1, FVector)
         @test (2 * fv1).type == TangentSpace
+        @test fv1[1] == tvs[1][1]
 
         PM = ProductManifold(Sphere(2), Euclidean(2))
         @test_throws ErrorException flat(
@@ -112,6 +113,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 DefaultOrthonormalBasis(),
                 get_basis(TpM, pts_TpM[1], DefaultOrthonormalBasis()),
             )
+            @test get_basis(TpM, pts_TpM[1], basis_types[2]) === basis_types[2]
             test_manifold(
                 TpM,
                 pts_TpM,
@@ -136,31 +138,33 @@ struct TestVectorSpaceType <: VectorSpaceType end
 
     @test base_manifold(TangentBundle(M)) == M
     @testset "spaces at point" begin
-        x = [1.0, 0.0, 0.0]
-        t_x = TangentSpaceAtPoint(M, x)
-        t_x2 = TangentSpace(M, x)
-        @test t_x == t_x2
-        ct_x = CotangentSpaceAtPoint(M, x)
-        t_xs = sprint(show, "text/plain", t_x)
-        sp = sprint(show, "text/plain", x)
+        p = [1.0, 0.0, 0.0]
+        t_p = TangentSpaceAtPoint(M, p)
+        t_p2 = TangentSpace(M, p)
+        @test t_p == t_p2
+        ct_p = CotangentSpaceAtPoint(M, p)
+        t_ps = sprint(show, "text/plain", t_p)
+        sp = sprint(show, "text/plain", p)
         sp = replace(sp, '\n' => "\n ")
-        t_xs_test = "Tangent space to the manifold $(M) at point:\n $(sp)"
-        @test t_xs == t_xs_test
-        @test base_manifold(t_x) == M
-        @test base_manifold(ct_x) == M
-        @test t_x.fiber.manifold == M
-        @test ct_x.fiber.manifold == M
-        @test t_x.fiber.fiber == TangentSpace
-        @test ct_x.fiber.fiber == CotangentSpace
-        @test t_x.point == x
-        @test ct_x.point == x
+        t_ps_test = "Tangent space to the manifold $(M) at point:\n $(sp)"
+        @test t_ps == t_ps_test
+        @test base_manifold(t_p) == M
+        @test base_manifold(ct_p) == M
+        @test t_p.fiber.manifold == M
+        @test ct_p.fiber.manifold == M
+        @test t_p.fiber.fiber == TangentSpace
+        @test ct_p.fiber.fiber == CotangentSpace
+        @test t_p.point == p
+        @test ct_p.point == p
+        @test injectivity_radius(t_p) == Inf
+        @test representation_size(t_p) == representation_size(M)
         # generic vector space at
         fiber = VectorBundleFibers(TestVectorSpaceType(), M)
-        v_x = VectorSpaceAtPoint(fiber, x)
-        v_xs = sprint(show, "text/plain", v_x)
+        v_p = VectorSpaceAtPoint(fiber, p)
+        v_ps = sprint(show, "text/plain", v_p)
         fiber_s = sprint(show, "text/plain", fiber)
-        v_xs_test = "$(typeof(v_x))\nFiber:\n $(fiber_s)\nBase point:\n $(sp)"
-        @test v_xs == v_xs_test
+        v_ps_test = "$(typeof(v_p))\nFiber:\n $(fiber_s)\nBase point:\n $(sp)"
+        @test v_ps == v_ps_test
     end
 
     @testset "tensor product" begin

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -104,7 +104,10 @@ struct TestVectorSpaceType <: VectorSpaceType end
             )
 
             # tangent space at point
-            pts_TpM = map(p -> convert(T, p), [[0.0, 0.0, 1.0], [0.0, 2.0, 0.0], [0.0, -1.0, 1.0]])
+            pts_TpM = map(
+                p -> convert(T, p),
+                [[0.0, 0.0, 1.0], [0.0, 2.0, 0.0], [0.0, -1.0, 1.0]],
+            )
             test_manifold(
                 TpM,
                 pts_TpM,

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -108,6 +108,10 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 p -> convert(T, p),
                 [[0.0, 0.0, 1.0], [0.0, 2.0, 0.0], [0.0, -1.0, 1.0]],
             )
+            basis_types = (
+                DefaultOrthonormalBasis(),
+                get_basis(TpM, pts_TpM[1], DefaultOrthonormalBasis()),
+            )
             test_manifold(
                 TpM,
                 pts_TpM,
@@ -119,7 +123,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 test_project_tangent = true,
                 test_project_point = true,
                 test_default_vector_transport = true,
-                basis_types_to_from = (DefaultOrthonormalBasis(),),
+                basis_types_vecs = basis_types,
                 projection_atol_multiplier = 4,
             )
         end


### PR DESCRIPTION
For https://github.com/JuliaManifolds/FunManifolds.jl/pull/10 I need a way to represent tangent space at a point as a manifold (for example for curves in the tangent space) so here I re-use `VectorSpaceAtPoint` for that.

Does this look reasonable?