### PR TITLE
Introduce ParallelTransport for Oblique

### DIFF
--- a/src/manifolds/Oblique.jl
+++ b/src/manifolds/Oblique.jl
@@ -88,6 +88,21 @@ end
 
 @generated representation_size(::Oblique{n,m}) where {n,m} = (n, m)
 
+@doc raw"""
+    vector_transport_to(M::Oblique, p, X, q, ::ParallelTransport)
+
+Compute the parallel transport on the [`Oblique`](@ref) manifold by
+doing a column wise parallel transport on the [`Sphere`](@ref)
+
+This is a shortcut to using [`PowerVectorTransport{ParallelTransport}`](@ref)
+from the [`AbstractPowerManifold`](@ref).
+"""
+vector_transport_to(::Oblique, ::Any, ::Any, ::Any, ::Any, ::ParallelTransport)
+
+function vector_transport_to!(M::Oblique, Y, p, X, q, m::ParallelTransport)
+    return vector_transport_to!(M, Y, p, X, q, PowerVectorTransport(m))
+end
+
 function Base.show(io::IO, ::Oblique{n,m,𝔽}) where {n,m,𝔽}
     return print(io, "Oblique($(n),$(m); field = $(𝔽))")
 end

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -23,6 +23,8 @@ where $\operatorname{Log}$ denotes the matrix logarithm and
 $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
 """
 function distance(M::SymmetricPositiveDefinite{N}, p, q) where {N}
+    # avoid numerical instabilities in cholesky
+    norm(p - q) < eps(eltype(p .+ q)) && return 0
     cq = cholesky(q)
     s = eigvals(Symmetric(cq.L \ p / cq.U))
     return any(s .<= eps()) ? zero(eltype(p)) : sqrt(sum(abs.(log.(s)) .^ 2))

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -24,7 +24,7 @@ $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
 """
 function distance(M::SymmetricPositiveDefinite{N}, p, q) where {N}
     # avoid numerical instabilities in cholesky
-    norm(p - q) < eps(eltype(p .+ q)) && return 0
+    norm(p - q) < eps(eltype(p + q)) && return zero(eltype(p + q))
     cq = cholesky(q)
     s = eigvals(Symmetric(cq.L \ p / cq.U))
     return any(s .<= eps()) ? zero(eltype(p)) : sqrt(sum(abs.(log.(s)) .^ 2))

--- a/test/oblique.jl
+++ b/test/oblique.jl
@@ -25,6 +25,7 @@ include("utils.jl")
         y = [1.0 0.0 0.0; 1/sqrt(2) 1/sqrt(2) 0.0]'
         z = [1/sqrt(2) 1/sqrt(2) 0.0; 1.0 0.0 0.0]'
         basis_types = (DefaultOrthonormalBasis(),)
+        transports = [ParallelTransport(), PowerVectorTransport(ParallelTransport())]
         test_manifold(
             M,
             [x, y, z],
@@ -33,7 +34,8 @@ include("utils.jl")
             test_vector_spaces = true,
             test_project_tangent = false,
             test_musical_isomorphisms = true,
-            test_default_vector_transport = false,
+            test_default_vector_transport = true,
+            vector_transport_methods = transports,
             basis_types_to_from = basis_types,
         )
     end


### PR DESCRIPTION
I think we should introduce `ParallelTransport`(and all other transports) a Manifold obtains from it “child” within an `AbstractPowerManifold` i.e. wrapping the `PowerTransportMethod`for ease of use for the user.

This PR introduces this for the Oblique manifold but surely we can check for more manifolds where this would be nice.