### PR TITLE
Fix transparency of get_vector! and get_coordinates! for AbstractGroupManifold

### DIFF
--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -89,14 +89,14 @@ end
 
 function decorator_transparent_dispatch(
     ::typeof(get_coordinates!),
-    ::AbstractGroupManifold,
+    ::AbstractGroupManifold{<:Any,<:AbstractGroupOperation,TransparentIsometricEmbedding},
     args...,
 )
     return Val(:transparent)
 end
 function decorator_transparent_dispatch(
     ::typeof(get_vector!),
-    ::AbstractGroupManifold,
+    ::AbstractGroupManifold{<:Any,<:AbstractGroupOperation,TransparentIsometricEmbedding},
     args...,
 )
     return Val(:transparent)

--- a/test/groups/groups_general.jl
+++ b/test/groups/groups_general.jl
@@ -346,11 +346,18 @@ struct NotImplementedAction <: AbstractGroupAction{LeftAction} end
     end
 end
 
-struct DefaultEmbeddedGroup <: AbstractGroupManifold{ℝ,AdditionOperation,DefaultEmbeddingType}
-end
+struct DefaultEmbeddedGroup <:
+       AbstractGroupManifold{ℝ,AdditionOperation,DefaultEmbeddingType} end
 
 @testset "DefaltEmbeddedGroup" begin
     G = DefaultEmbeddedGroup()
-    @test ManifoldsBase.decorator_transparent_dispatch(get_vector!, G, [1], [1], [1]) === Val(:parent)
-    @test ManifoldsBase.decorator_transparent_dispatch(get_coordinates!, G, [1], [1], [1]) === Val(:parent)
+    @test ManifoldsBase.decorator_transparent_dispatch(get_vector!, G, [1], [1], [1]) ===
+          Val(:parent)
+    @test ManifoldsBase.decorator_transparent_dispatch(
+        get_coordinates!,
+        G,
+        [1],
+        [1],
+        [1],
+    ) === Val(:parent)
 end

--- a/test/groups/groups_general.jl
+++ b/test/groups/groups_general.jl
@@ -345,3 +345,12 @@ struct NotImplementedAction <: AbstractGroupAction{LeftAction} end
         @test_throws ErrorException optimal_alignment!(A, a, x, x)
     end
 end
+
+struct DefaultEmbeddedGroup <: AbstractGroupManifold{ℝ,AdditionOperation,DefaultEmbeddingType}
+end
+
+@testset "DefaltEmbeddedGroup" begin
+    G = DefaultEmbeddedGroup()
+    @test ManifoldsBase.decorator_transparent_dispatch(get_vector!, G, [1], [1], [1]) === Val(:parent)
+    @test ManifoldsBase.decorator_transparent_dispatch(get_coordinates!, G, [1], [1], [1]) === Val(:parent)
+end


### PR DESCRIPTION
I think this was wrongly defined in #251 .