### PR TITLE
Stabilize SPD distance and a small fix to TangentBundle

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -22,10 +22,10 @@ d_{\mathcal P(n)}(p,q)
 where $\operatorname{Log}$ denotes the matrix logarithm and
 $\lVert\cdot\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
 """
-function distance(M::SymmetricPositiveDefinite{N}, p, q) where {N}
+function distance(::SymmetricPositiveDefinite{N}, p, q) where {N}
     # avoid numerical instabilities in cholesky
     norm(p - q) < eps(eltype(p + q)) && return zero(eltype(p + q))
-    cq = cholesky(q)
+    cq = cholesky(Symmetric(q)) # to avoid numerical inaccuracies
     s = eigvals(Symmetric(cq.L \ p / cq.U))
     return any(s .<= eps()) ? zero(eltype(p)) : sqrt(sum(abs.(log.(s)) .^ 2))
 end
@@ -46,7 +46,7 @@ where $\operatorname{Exp}$ denotes to the matrix exponential.
 """
 exp(::SymmetricPositiveDefinite, ::Any...)
 
-function exp!(M::SymmetricPositiveDefinite{N}, q, p, X) where {N}
+function exp!(::SymmetricPositiveDefinite{N}, q, p, X) where {N}
     e = eigen(Symmetric(p))
     U = e.vectors
     S = e.values
@@ -73,7 +73,7 @@ Return a orthonormal basis `Ξ` as a vector of tangent vectors (of length
 with eigenvalues `κ` and where the direction `B.frame_direction` has curvature `0`.
 """
 function get_basis(
-    M::SymmetricPositiveDefinite{N},
+    ::SymmetricPositiveDefinite{N},
     p,
     B::DiagonalizingOrthonormalBasis,
 ) where {N}
@@ -95,7 +95,7 @@ function get_coordinates!(
     Y,
     p,
     X,
-    B::DefaultOrthonormalBasis,
+    ::DefaultOrthonormalBasis,
 ) where {N}
     dim = manifold_dimension(M)
     @assert size(Y) == (dim,)
@@ -115,7 +115,7 @@ function get_vector!(
     Y,
     p,
     X,
-    B::DefaultOrthonormalBasis,
+    ::DefaultOrthonormalBasis,
 ) where {N}
     dim = manifold_dimension(M)
     @assert size(X) == (div(N * (N + 1), 2),)
@@ -142,7 +142,7 @@ a [`MetricManifold`](@ref) with [`LinearAffineMetric`](@ref). The formula reads
 g_p(X,Y) = \operatorname{tr}(p^{-1} X p^{-1} Y),
 ````
 """
-function inner(M::SymmetricPositiveDefinite, p, X, Y)
+function inner(::SymmetricPositiveDefinite, p, X, Y)
     F = cholesky(Symmetric(p))
     return tr((F \ Symmetric(X)) * (F \ Symmetric(Y)))
 end

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -633,7 +633,7 @@ function inner(B::VectorBundle, p, X, Y)
     px, Vx = submanifold_components(B.manifold, p)
     VXM, VXF = submanifold_components(B.manifold, X)
     VYM, VYF = submanifold_components(B.manifold, Y)
-    return inner(B.manifold, px, VXM, VYM) + inner(B.fiber, Vx, VXF, VYF)
+    return inner(B.manifold, px, VXM, VYM) + inner(VectorSpaceAtPoint(B.fiber, px), Vx, VXF, VYF)
 end
 function inner(B::TangentBundle, p, X, Y)
     px, Vx = submanifold_components(B.manifold, p)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -76,7 +76,7 @@ CotangentBundleFibers(M::Manifold) = VectorBundleFibers(CotangentSpace, M)
         𝔽,
         TFiber<:VectorBundleFibers{<:VectorSpaceType,<:Manifold{𝔽}},
         TX,
-    } <: Manifold{𝔽}   
+    } <: Manifold{𝔽}
 
 A vector space at a point `p` on the manifold.
 This is modelled using [`VectorBundleFibers`](@ref) with only a vector-like part
@@ -634,6 +634,12 @@ function inner(B::VectorBundle, p, X, Y)
     VXM, VXF = submanifold_components(B.manifold, X)
     VYM, VYF = submanifold_components(B.manifold, Y)
     return inner(B.manifold, px, VXM, VYM) + inner(B.fiber, Vx, VXF, VYF)
+end
+function inner(B::TangentBundle, p, X, Y)
+    px, Vx = submanifold_components(B.manifold, p)
+    VXM, VXF = submanifold_components(B.manifold, X)
+    VYM, VYF = submanifold_components(B.manifold, Y)
+    return inner(B.manifold, px, VXM, VYM) + inner(B.manifold, px, VXF, VYF)
 end
 """
     inner(M::TangentSpaceAtPoint, p, X, Y)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -633,14 +633,10 @@ function inner(B::VectorBundle, p, X, Y)
     px, Vx = submanifold_components(B.manifold, p)
     VXM, VXF = submanifold_components(B.manifold, X)
     VYM, VYF = submanifold_components(B.manifold, Y)
-    return inner(B.manifold, px, VXM, VYM) + inner(VectorSpaceAtPoint(B.fiber, px), Vx, VXF, VYF)
+    return inner(B.manifold, px, VXM, VYM) +
+           inner(VectorSpaceAtPoint(B.fiber, px), Vx, VXF, VYF)
 end
-function inner(B::TangentBundle, p, X, Y)
-    px, Vx = submanifold_components(B.manifold, p)
-    VXM, VXF = submanifold_components(B.manifold, X)
-    VYM, VYF = submanifold_components(B.manifold, Y)
-    return inner(B.manifold, px, VXM, VYM) + inner(B.manifold, px, VXF, VYF)
-end
+
 """
     inner(M::TangentSpaceAtPoint, p, X, Y)
 


### PR DESCRIPTION
This is just a small bug fix PR.

We noticed that `cholesky` gets very unstable when the matrix is not symmetric (and one disables the checks). With an added `Symmetric` it works fine and is accurate again.

Furthermore for tangent bundle the inner was not working. A tangent vector to the tangent bundle is basically two tangent vectors, so the second (tangent components) inner has to also use the base-base point as inner. @mateuszbaran can you check whether this also holds for the vector bundle? Then we could unify both implementations again.