### PR TITLE
Semantic access to points on tangent and cotangent bundle

### DIFF
--- a/docs/src/manifolds/vector_bundle.md
+++ b/docs/src/manifolds/vector_bundle.md
@@ -21,6 +21,21 @@ This is also considered a manifold.
 For cases where confusion between different types of vectors is possible, the type [`FVector`](@ref) can be used to express which type of vector space the vector belongs to.
 It is used for example in musical isomorphisms (the [`flat`](@ref) and [`sharp`](@ref) functions) that are used to go from a tangent space to cotangent space and vice versa.
 
+## Example
+
+The following code defines two points on a tangent bundle of the sphere $S^2$ and calculates distance between them, distance between their base points and norm of one of these tangent vectors.
+
+```@example
+using Manifolds
+M = Sphere(2)
+TB = TangentBundle(M)
+p = ProductRepr([1.0, 0.0, 0.0], [0.0, 1.0, 3.0])
+q = ProductRepr([0.0, 1.0, 0.0], [2.0, 0.0, -1.0])
+println("Distance between p and q: ", distance(TB, p, q))
+println("Distance between base points of p and q: ", distance(M, p[TB, :point], q[TB, :point]))
+println("Norm of p: ", norm(M, p[TB, :point], p[TB, :vector]))
+```
+
 ```@autodocs
 Modules = [Manifolds, ManifoldsBase]
 Pages = ["manifolds/VectorBundle.jl"]

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -109,6 +109,7 @@ include("distributions.jl")
 include("projected_distribution.jl")
 include("product_representations.jl")
 
+
 # It's included early to ensure visibility of `Identity`
 include("groups/group.jl")
 

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -103,11 +103,12 @@ include("errors.jl")
 
 include("statistics.jl")
 
+include("product_representations.jl")
+
 include("manifolds/VectorBundle.jl")
 
 include("distributions.jl")
 include("projected_distribution.jl")
-include("product_representations.jl")
 
 
 # It's included early to ensure visibility of `Identity`

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -582,11 +582,11 @@ end
 Base.@propagate_inbounds Base.getindex(x::FVector, i) = getindex(x.data, i)
 
 """
-    getindex(p::ProductRepr, M::CotangentBundle, s::Symbol
-    p[M::CotangentBundle, s]
+    getindex(p::ProductRepr, M::VectorBundle, s::Symbol)
+    p[M::VectorBundle, s]
 
-Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
-using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
+Access the element(s) at index `s` of a point `p` on a [`VectorBundle`](@ref) `M` by
+using the symbols `:point` and `:vector` for the base and vector component, respectively.
 """
 @inline function Base.getindex(p::ProductRepr, M::VectorBundle, s::Symbol)
     (s === :point) && return submanifold_component(M, p, Val(1))
@@ -832,6 +832,17 @@ end
 
 Base.@propagate_inbounds Base.setindex!(x::FVector, val, i) = setindex!(x.data, val, i)
 
+"""
+    setindex!(p::ProductRepr, val, M::VectorBundle, s::Symbol)
+    p[M::VectorBundle, s] = val
+
+Set the element(s) at index `s` of a point `p` on a [`VectorBundle`](@ref) `M` to `val` by
+using the symbols `:point` and `:vector` for the base and vector component, respectively.
+
+!!! note
+
+    The *content* of element of `p` is replaced, not the element itself.
+"""
 @inline function Base.setindex!(x::ProductRepr, val, M::VectorBundle, s::Symbol)
     if s === :point
         return copyto!(submanifold_component(M, x, Val(1)), val)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -581,6 +581,74 @@ end
 
 Base.@propagate_inbounds Base.getindex(x::FVector, i) = getindex(x.data, i)
 
+"""
+    getindex(p::ProductRepr, M::CotangentBundle, s::Symbol
+    p[M::CotangentBundle, s]
+
+Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
+using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
+"""
+Base.@propagate_inbounds function Base.getindex(
+    p::ProductRepr,
+    M::TangentBundle,
+    s::Symbol
+)
+    (s==:base) && return submanifold_component(M,p,1)
+    (s==:ctangent) && return submanifold_component(M,p,2)
+    throw(DomainError(s, "unknown vomponent on $s on $M."))
+end
+
+"""
+    getindex(p::ProductRepr, M::TangentBundle, s::Symbol
+    p[M::TangentBundle, s]
+
+Access the element(s) at index `s` of a point `p` on a [`Tangentbundle`](@ref) `M` by
+using the symbols `:base` and `:tangent` for the base and tangent component, respectively.
+"""
+Base.@propagate_inbounds function Base.getindex(
+    p::ProductRepr,
+    M::TangentBundle,
+    s::Symbol
+)
+    (s==:base) && return submanifold_component(M,p,1)
+    (s==:tangent) && return submanifold_component(M,p,2)
+    throw(DomainError(s, "unknown vomponent on $s on $M."))
+end
+
+"""
+    getindex(p::ProductArray, M::CotangentBundle, s::Symbol
+    p[M::CotangentBundle, s]
+
+Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
+using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
+"""
+Base.@propagate_inbounds function Base.getindex(
+    p::PtRepr,
+    M::TangentBundle,
+    s::Symbol
+)
+    (s==:base) && return p[M,1]
+    (s==:cotangent) && return p[M,2]
+    throw(DomainError(s, "unknown vomponent on $s on $M."))
+end
+
+"""
+    getindex(p::ProductArray, M::CotangentBundle, s::Symbol
+    p[M::CotangentBundle, s]
+
+Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
+using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
+"""
+Base.@propagate_inbounds function Base.getindex(
+    p::ProductArray,
+    M::TangentBundle,
+    s::Symbol
+)
+    (s==:base) && return p[M,1]
+    (s==:tangent) && return p[M,2]
+    throw(DomainError(s, "unknown vomponent on $s on $M."))
+end
+
 @doc raw"""
     injectivity_radius(M::TangentSpaceAtPoint)
 
@@ -702,7 +770,7 @@ function log!(B::VectorBundle, X, p, q)
     copyto!(VXF, VXF - Vx)
     return X
 end
-function log!(M::TangentSpaceAtPoint, X, p, q)
+function log!(::TangentSpaceAtPoint, X, p, q)
     copyto!(X, q - p)
     return X
 end
@@ -818,6 +886,18 @@ function project!(B::VectorBundleFibers, Y, p, X)
 end
 
 Base.@propagate_inbounds Base.setindex!(x::FVector, val, i) = setindex!(x.data, val, i)
+
+function Base.@propagate_inbounds Base.setindex!(x::ProductArray, M::CotangentBundle, s::Symbol)
+    (s===:base) && return setindex!(x.data, val, 1)
+    (s===:cotangent) && return setindex(x.data, val, 2)
+    throw(DomainError(s, "Can not set index $s of a point $x on $M: Unknown component. Expected `:base` or `:cotangent`"))
+end
+
+function Base.@propagate_inbounds Base.setindex!(x::ProductArray, M::TangentBundle, s::Symbol)
+    (s===:base) && return setindex!(x.data, val, 1)
+    (s===:tangent) && return setindex(x.data, val, 2)
+    throw(DomainError(s, "Can not set index $s of a point $x on $M: Unknown component. Expected `:base` or `:tangent`"))
+end
 
 function representation_size(B::VectorBundleFibers{<:TCoTSpaceType})
     return representation_size(B.manifold)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -588,65 +588,10 @@ Base.@propagate_inbounds Base.getindex(x::FVector, i) = getindex(x.data, i)
 Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
 using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
 """
-Base.@propagate_inbounds function Base.getindex(
-    p::ProductRepr,
-    M::TangentBundle,
-    s::Symbol
-)
-    (s==:base) && return submanifold_component(M,p,1)
-    (s==:ctangent) && return submanifold_component(M,p,2)
-    throw(DomainError(s, "unknown vomponent on $s on $M."))
-end
-
-"""
-    getindex(p::ProductRepr, M::TangentBundle, s::Symbol
-    p[M::TangentBundle, s]
-
-Access the element(s) at index `s` of a point `p` on a [`Tangentbundle`](@ref) `M` by
-using the symbols `:base` and `:tangent` for the base and tangent component, respectively.
-"""
-Base.@propagate_inbounds function Base.getindex(
-    p::ProductRepr,
-    M::TangentBundle,
-    s::Symbol
-)
-    (s==:base) && return submanifold_component(M,p,1)
-    (s==:tangent) && return submanifold_component(M,p,2)
-    throw(DomainError(s, "unknown vomponent on $s on $M."))
-end
-
-"""
-    getindex(p::ProductArray, M::CotangentBundle, s::Symbol
-    p[M::CotangentBundle, s]
-
-Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
-using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
-"""
-Base.@propagate_inbounds function Base.getindex(
-    p::PtRepr,
-    M::TangentBundle,
-    s::Symbol
-)
-    (s==:base) && return p[M,1]
-    (s==:cotangent) && return p[M,2]
-    throw(DomainError(s, "unknown vomponent on $s on $M."))
-end
-
-"""
-    getindex(p::ProductArray, M::CotangentBundle, s::Symbol
-    p[M::CotangentBundle, s]
-
-Access the element(s) at index `s` of a point `p` on a [`Cotangentbundle`](@ref) `M` by
-using the symbols `:base` and `:cotangent` for the base and tangent component, respectively.
-"""
-Base.@propagate_inbounds function Base.getindex(
-    p::ProductArray,
-    M::TangentBundle,
-    s::Symbol
-)
-    (s==:base) && return p[M,1]
-    (s==:tangent) && return p[M,2]
-    throw(DomainError(s, "unknown vomponent on $s on $M."))
+@inline function Base.getindex(p::ProductRepr, M::VectorBundle, s::Symbol)
+    (s === :point) && return submanifold_component(M, p, Val(1))
+    (s === :vector) && return submanifold_component(M, p, Val(2))
+    return throw(DomainError(s, "unknown component $s on $M."))
 end
 
 @doc raw"""
@@ -887,16 +832,14 @@ end
 
 Base.@propagate_inbounds Base.setindex!(x::FVector, val, i) = setindex!(x.data, val, i)
 
-function Base.@propagate_inbounds Base.setindex!(x::ProductArray, M::CotangentBundle, s::Symbol)
-    (s===:base) && return setindex!(x.data, val, 1)
-    (s===:cotangent) && return setindex(x.data, val, 2)
-    throw(DomainError(s, "Can not set index $s of a point $x on $M: Unknown component. Expected `:base` or `:cotangent`"))
-end
-
-function Base.@propagate_inbounds Base.setindex!(x::ProductArray, M::TangentBundle, s::Symbol)
-    (s===:base) && return setindex!(x.data, val, 1)
-    (s===:tangent) && return setindex(x.data, val, 2)
-    throw(DomainError(s, "Can not set index $s of a point $x on $M: Unknown component. Expected `:base` or `:tangent`"))
+@inline function Base.setindex!(x::ProductRepr, val, M::VectorBundle, s::Symbol)
+    if s === :point
+        return copyto!(submanifold_component(M, x, Val(1)), val)
+    elseif s === :vector
+        return copyto!(submanifold_component(M, x, Val(2)), val)
+    else
+        throw(DomainError(s, "unknown component $s on $M."))
+    end
 end
 
 function representation_size(B::VectorBundleFibers{<:TCoTSpaceType})

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -60,6 +60,10 @@ struct TestVectorSpaceType <: VectorSpaceType end
         @test p[TB, :vector] === p.parts[2]
         p[TB, :vector] = [0.0, 3.0, 1.0]
         @test p.parts[2] == [0.0, 3.0, 1.0]
+        p[TB, :point] = [0.0, 1.0, 0.0]
+        @test p.parts[1] == [0.0, 1.0, 0.0]
+        @test_throws DomainError p[TB, :error]
+        @test_throws DomainError p[TB, :error] = [1,2,3]
     end
 
     types = [Vector{Float64}]

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -63,7 +63,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
         p[TB, :point] = [0.0, 1.0, 0.0]
         @test p.parts[1] == [0.0, 1.0, 0.0]
         @test_throws DomainError p[TB, :error]
-        @test_throws DomainError p[TB, :error] = [1,2,3]
+        @test_throws DomainError p[TB, :error] = [1, 2, 3]
     end
 
     types = [Vector{Float64}]

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -53,6 +53,15 @@ struct TestVectorSpaceType <: VectorSpaceType end
         @test submanifold_components(PM, fv2) == ([1.0, 0.0, 0.0], [1.0 2.0])
     end
 
+    @testset "Nice access to vector bundle components" begin
+        TB = TangentBundle(M)
+        p = ProductRepr([1.0, 0.0, 0.0], [0.0, 2.0, 4.0])
+        @test p[TB, :point] === p.parts[1]
+        @test p[TB, :vector] === p.parts[2]
+        p[TB, :vector] = [0.0, 3.0, 1.0]
+        @test p.parts[2] == [0.0, 3.0, 1.0]
+    end
+
     types = [Vector{Float64}]
     TEST_FLOAT32 && push!(types, Vector{Float32})
     TEST_STATIC_SIZED && push!(types, MVector{3,Float64})


### PR DESCRIPTION
This PR aims to provide
* `p[M, :base]`
* `p[M, :Tangen]`and `p[M, :cotangent]`, respectively,

but today seems to be the case of ideas, that are too clever for me.

* ProductRepr and ProductArray are only loaded after bundle and I am not sure why, but I can't change the order just now
* I am not sure a `setindex!`would work with `ProductRepr`
* I am not sure a `ProductArray` is useful for (co)tangent bundles, since I cound find no documentation on how to construct/use `ProductArray`s (only that `ProductRepr`which I used until now may be slower than the thing I can't construct).