### PR TITLE
CompatHelper: bump compat for "StaticArrays" to "1.0"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ RecipesBase = "1.1"
 Requires = "0.5, 1"
 SimpleWeightedGraphs = "1"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
-StaticArrays = "0.12"
+StaticArrays = "0.12, 1.0"
 StatsBase = "0.32, 0.33"
 julia = "1.3"
 


### PR DESCRIPTION
This pull request changes the compat entry for the `StaticArrays` package from `0.12` to `0.12, 1.0`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.