### PR TITLE
Updates to SkewSymmetricMatrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.4.22"
+version = "0.4.23"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -415,7 +415,7 @@ inverse_retract(::Rotations, ::Any, ::Any, ::QRInverseRetraction)
 function inverse_retract!(M::Rotations, X, p, q, method::PolarInverseRetraction)
     A = transpose(p) * q
     Amat = A isa StaticMatrix ? A : convert(Matrix, A)
-    H = copyto!(allocate(Amat), 2I)
+    H = copyto!(allocate(Amat), -2I)
     try
         B = lyap(A, A, H)
     catch e

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -630,7 +630,7 @@ where tangent vectors are represented by elements from the Lie group
 """
 project(::Rotations, ::Any, ::Any)
 
-project!(M::Rotations, Y, p, X) = (Y .= (X .- transpose(X)) ./ 2)
+project!(M::Rotations{N}, Y, p, X) where {N} = project!(SkewSymmetricMatrices(N), Y, X)
 
 @doc raw"""
     representation_size(M::Rotations)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -107,7 +107,7 @@ function check_tangent_vector(
         perr = check_manifold_point(M, p)
         perr === nothing || return perr
     end
-    return check_manifold_point(SkewSymmetricMatrices(n), X)
+    return check_manifold_point(SkewSymmetricMatrices(N), X)
 end
 
 @doc raw"""

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -107,19 +107,7 @@ function check_tangent_vector(
         perr = check_manifold_point(M, p)
         perr === nothing || return perr
     end
-    if size(X) != (N, N)
-        return DomainError(
-            size(X),
-            "The array $(X) is not a tangent to a point on $M since its size does not match $((N, N)).",
-        )
-    end
-    if !isapprox(transpose(X) + X, zero(X); kwargs...)
-        return DomainError(
-            size(X),
-            "The array $(X) is not a tangent to a point on $M since it is not skew-symmetric.",
-        )
-    end
-    return nothing
+    return check_manifold_point(SkewSymmetricMatrices(n), X)
 end
 
 @doc raw"""

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -426,7 +426,7 @@ function inverse_retract!(M::Rotations, X, p, q, method::PolarInverseRetraction)
             rethrow()
         end
     end
-    return project!(M, p, X)
+    return project!(M, X, p, X)
 end
 function inverse_retract!(M::Rotations{N}, X, p, q, ::QRInverseRetraction) where {N}
     A = transpose(p) * q
@@ -438,7 +438,7 @@ function inverse_retract!(M::Rotations{N}, X, p, q, ::QRInverseRetraction) where
         R[1:i, i] = A[1:i, 1:i] \ b
     end
     mul!(X, A, R)
-    return project!(M, p, X)
+    return project!(M, X, p, X)
 end
 
 @doc raw"""
@@ -480,7 +480,7 @@ function log!(M::Rotations{3}, X, p, q)
         return get_vector!(M, X, p, π * ax, DefaultOrthogonalBasis())
     end
     X .= U ./ usinc_from_cos(cosθ)
-    return project!(M, p, X)
+    return project!(M, X, p, X)
 end
 function log!(M::Rotations{4}, X, p, q)
     U = transpose(p) * q

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -417,7 +417,8 @@ function inverse_retract!(M::Rotations, X, p, q, method::PolarInverseRetraction)
     Amat = A isa StaticMatrix ? A : convert(Matrix, A)
     H = copyto!(allocate(Amat), -2I)
     try
-        B = lyap(A, A, H)
+        B = lyap(A, H)
+        mul!(X, A, B)
     catch e
         if isa(e, LinearAlgebra.LAPACKException)
             throw(OutOfInjectivityRadiusError())
@@ -425,7 +426,6 @@ function inverse_retract!(M::Rotations, X, p, q, method::PolarInverseRetraction)
             rethrow()
         end
     end
-    mul!(X, A, B)
     return project!(M, p, X)
 end
 function inverse_retract!(M::Rotations{N}, X, p, q, ::QRInverseRetraction) where {N}

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -208,7 +208,10 @@ where $\cdot^{\mathrm{H}}$ denotes the Hermitian, i.e. complex conjugate transpo
 """
 project(::SkewSymmetricMatrices, ::Any)
 
-project!(M::SkewSymmetricMatrices, q, p) = copyto!(q, (p - p') ./ 2)
+function project!(M::SkewSymmetricMatrices, q, p)
+    q .= (p .- p') ./ 2
+    return q
+end
 
 @doc raw"""
     project(M::SkewSymmetricMatrices, p, X)

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -78,7 +78,7 @@ function check_tangent_vector(
         mpe = check_manifold_point(M, p; kwargs...)
         mpe === nothing || return mpe
     end
-    return check_base_point(M, X; kwargs...)  # manifold is its own tangent space
+    return check_manifold_point(M, X; kwargs...)  # manifold is its own tangent space
 end
 
 decorated_manifold(M::SkewSymmetricMatrices{N,𝔽}) where {N,𝔽} = Euclidean(N, N; field=𝔽)

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -180,20 +180,19 @@ end
 @doc raw"""
     manifold_dimension(M::SkewSymmetricMatrices{n,𝔽})
 
-Return the dimension of the [`SkewSymmetricMatrices`](@ref) matrix `M` over the number system
-`𝔽`, i.e.
+Return the dimension of the [`SkewSymmetricMatrices`](@ref) matrix `M` over the number
+system `𝔽`, i.e.
 
 ````math
-\begin{aligned}
-\dim \mathrm{SkewSym}(n,ℝ) &= \frac{n(n-1)}{2},\\
-\dim \mathrm{SkewSym}(n,ℂ) &= 2*\frac{n(n-1)}{2} + n = n^2,
-\end{aligned}
+\dim \mathrm{SkewSym}(n,ℝ) &= \frac{n(n+1)}{2} \dim_ℝ 𝔽 - n,\\
 ````
 
-where the last $n$ is due to an imaginary diagonal that is allowed $\dim_ℝ 𝔽$ is the [`real_dimension`](@ref) of `𝔽`.
+where ``\dim_ℝ 𝔽`` is the [`real_dimension`](@ref) of ``𝔽``. The first term corresponds to
+only the upper triangular elements of the matrix being unique, and the second term
+corresponds to the constraint that the real part of the diagonal be zero.
 """
 function manifold_dimension(::SkewSymmetricMatrices{N,𝔽}) where {N,𝔽}
-    return div(N * (N - 1), 2) * real_dimension(𝔽) + (𝔽 === ℂ ? N : 0)
+    return div(N * (N + 1), 2) * real_dimension(𝔽) + N
 end
 
 @doc raw"""

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -46,8 +46,7 @@ whether `p` is a skew-symmetric matrix of size `(n,n)` with values from the corr
 The tolerance for the skew-symmetry of `p` can be set using `kwargs...`.
 """
 function check_manifold_point(M::SkewSymmetricMatrices{n,𝔽}, p; kwargs...) where {n,𝔽}
-    mpv =
-        invoke(check_manifold_point, Tuple{supertype(typeof(M)),typeof(p)}, M, p; kwargs...)
+    mpv = check_manifold_point(decorated_manifold(M), p; kwargs...)
     mpv === nothing || return mpv
     if !isapprox(p, -p'; kwargs...)
         return DomainError(
@@ -59,7 +58,7 @@ function check_manifold_point(M::SkewSymmetricMatrices{n,𝔽}, p; kwargs...) wh
 end
 
 """
-    check_tangent_vector(M::SkewSymmetricMatrices{n,𝔽}, p, X; check_base_point = true, kwargs... )
+    check_tangent_vector(M::SkewSymmetricMatrices{n}, p, X; check_base_point = true, kwargs... )
 
 Check whether `X` is a tangent vector to manifold point `p` on the
 [`SkewSymmetricMatrices`](@ref) `M`, i.e. `X` has to be a skew-symmetric matrix of size `(n,n)`
@@ -69,33 +68,17 @@ The optional parameter `check_base_point` indicates, whether to call
 The tolerance for the skew-symmetry of `p` and `X` can be set using `kwargs...`.
 """
 function check_tangent_vector(
-    M::SkewSymmetricMatrices{n,𝔽},
+    M::SkewSymmetricMatrices,
     p,
     X;
     check_base_point=true,
     kwargs...,
-) where {n,𝔽}
+)
     if check_base_point
         mpe = check_manifold_point(M, p; kwargs...)
         mpe === nothing || return mpe
     end
-    mpv = invoke(
-        check_tangent_vector,
-        Tuple{supertype(typeof(M)),typeof(p),typeof(X)},
-        M,
-        p,
-        X;
-        check_base_point=false, # already checked above
-        kwargs...,
-    )
-    mpv === nothing || return mpv
-    if !isapprox(norm(X + adjoint(X)), 0.0; kwargs...)
-        return DomainError(
-            norm(X + adjoint(X)),
-            "The vector $(X) is not a tangent vector to $(p) on $(M), since it is not symmetric.",
-        )
-    end
-    return nothing
+    return check_base_point(M, X; kwargs...)  # manifold is its own tangent space
 end
 
 decorated_manifold(M::SkewSymmetricMatrices{N,𝔽}) where {N,𝔽} = Euclidean(N, N; field=𝔽)

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -226,7 +226,7 @@ where $\cdot^{\mathrm{H}}$ denotes the Hermitian, i.e. complex conjugate transpo
 """
 project(::SkewSymmetricMatrices, ::Any, ::Any)
 
-project!(M::SkewSymmetricMatrices, Y, p, X) = (Y .= (X .- X') ./ 2)
+project!(M::SkewSymmetricMatrices, Y, p, X) = project!(M, Y, X)
 
 function Base.show(io::IO, ::SkewSymmetricMatrices{n,F}) where {n,F}
     return print(io, "SkewSymmetricMatrices($(n), $(F))")

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -192,7 +192,7 @@ only the upper triangular elements of the matrix being unique, and the second te
 corresponds to the constraint that the real part of the diagonal be zero.
 """
 function manifold_dimension(::SkewSymmetricMatrices{N,𝔽}) where {N,𝔽}
-    return div(N * (N + 1), 2) * real_dimension(𝔽) + N
+    return div(N * (N + 1), 2) * real_dimension(𝔽) - N
 end
 
 @doc raw"""

--- a/src/manifolds/SkewSymmetric.jl
+++ b/src/manifolds/SkewSymmetric.jl
@@ -49,10 +49,10 @@ function check_manifold_point(M::SkewSymmetricMatrices{n,𝔽}, p; kwargs...) wh
     mpv =
         invoke(check_manifold_point, Tuple{supertype(typeof(M)),typeof(p)}, M, p; kwargs...)
     mpv === nothing || return mpv
-    if !isapprox(norm(p + p'), 0.0; kwargs...)
+    if !isapprox(p, -p'; kwargs...)
         return DomainError(
             norm(p + p'),
-            "The point $(p) does not lie on $M, since it is not symmetric.",
+            "The point $(p) does not lie on $M, since it is not skew-symmetric.",
         )
     end
     return nothing


### PR DESCRIPTION
This PR makes several non-breaking changes to `SkewSymmetricMatrices` and also reuses its functionality when possible for the tangent vectors of `Rotations`.