### PR TITLE
A getindex for product manifold

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.4.25"
+version = "0.4.26"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -26,7 +26,7 @@ end
 
 access the `i`th manifold component from the [`ProductManifold`](@ref) `M`.
 """
-@inline Base.getindex(M::ProductManifold, i) = M.manifolds[i]
+@inline Base.getindex(M::ProductManifold, i::Integer) = M.manifolds[i]
 
 ProductManifold() = throw(MethodError("No method matching ProductManifold()."))
 

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -20,6 +20,14 @@ function ProductManifold(manifolds::Manifold...)
     return ProductManifold{𝔽,typeof(manifolds)}(manifolds)
 end
 
+"""
+    getindex(M::ProductManifold, i)
+    M[i]
+
+access the `i`th manifold component from the [`ProductManifold`](@ref) `M`.
+"""
+@inline Base.getindex(M::ProductManifold, i) = M.manifolds[i]
+
 ProductManifold() = throw(MethodError("No method matching ProductManifold()."))
 
 const PRODUCT_BASIS_LIST = [

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -19,6 +19,8 @@ end
     @test Mse == ProductManifold(M1) × M2
     @test Mse == ProductManifold(M1) × ProductManifold(M2)
     @test Mse == M1 × ProductManifold(M2)
+    @test Mse[1] == M1
+    @test Mse[2] == M2
     @test injectivity_radius(Mse) ≈ π
     @test injectivity_radius(
         Mse,


### PR DESCRIPTION
While workingg on JuliaManifolds/Manopt.jl#79 I noticed that an `getindex` is nice when working with manifolds, so similar to accessing `ProductRepr` as `x[M,1]` not accessing the first component of a product manifold `M` is just `M[1]`.