### PR TITLE
CompatHelper: bump compat for "Distributions" to "0.25"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Colors = "0.12"
-Distributions = "0.22.6, 0.23, 0.24"
+Distributions = "0.22.6, 0.23, 0.24, 0.25"
 Einsum = "0.4"
 FiniteDiff = "2"
 FiniteDifferences = "0.12"


### PR DESCRIPTION
This pull request changes the compat entry for the `Distributions` package from `0.22.6, 0.23, 0.24` to `0.22.6, 0.23, 0.24, 0.25`.

This keeps the compat entries for earlier versions.

Note: I have not tested your package with this new compat entry. It is your responsibility to make sure that your package tests pass before you merge this pull request.