### PR TITLE
Fix behaviour of christioffel symbol functions and related Jacobians 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.4.26"
+version = "0.4.27"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -21,8 +21,6 @@ import ManifoldsBase:
     embed!,
     exp!,
     exp!__intransparent,
-    # TODO: uncomment the import if `flat!` goes to ManifoldsBase
-    # flat!__intransparent,
     get_basis,
     get_component,
     get_coordinates,
@@ -40,7 +38,7 @@ import ManifoldsBase:
     is_tangent_vector,
     inverse_retract,
     inverse_retract!,
-    log, #for extension, e.g. in Stiefel.
+    log,
     log!,
     manifold_dimension,
     mid_point,

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -283,10 +283,14 @@ inner(::Euclidean, ::Any...)
 function inverse_local_metric(M::MetricManifold{𝔽,<:Manifold,EuclideanMetric}, p) where {𝔽}
     return local_metric(M, p)
 end
+inverse_local_metric(M::Euclidean, p) = local_metric(M, p)
 
 default_metric_dispatch(::Euclidean, ::EuclideanMetric) = Val(true)
 
 function local_metric(::MetricManifold{𝔽,<:Manifold,EuclideanMetric}, p) where {𝔽}
+    return Diagonal(ones(SVector{size(p, 1),eltype(p)}))
+end
+function local_metric(::Euclidean, p)
     return Diagonal(ones(SVector{size(p, 1),eltype(p)}))
 end
 

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -4,12 +4,13 @@
 Abstract type for the pseudo-Riemannian metric tensor ``g``, a family of smoothly
 varying inner products on the tangent space. See [`inner`](@ref).
 
-# Constructors
+# Functor
 
-    Metric(M)
+    (metric::Metric)(M::Manifold)
 
-Generate the manifold `M` with the correstponding metric (subtype of this type).
-See also [`MetricManifold`](@ref).
+Generate the `MetricManifold` that wraps the manifold `M` with given `metric`.
+This works for both a variable containing the metric as well as a subtype `T<:Metric`,
+where a zero parameter constructor `T()` is availabe.
 """
 abstract type Metric end
 
@@ -562,7 +563,7 @@ The matrix has the property that ``g(X, Y)=X^\mathrm{T} [g_{ij}] Y = g_{ij} X^i 
 where the latter expression uses Einstein summation convention.
 """
 local_metric(::Manifold, ::Any...)
-@decorator_transparent_signature local_metric(M::Manifold, p; kwargs...)
+@decorator_transparent_signature local_metric(M::AbstractDecoratorManifold, p; kwargs...)
 function decorator_transparent_dispatch(::typeof(local_metric), ::MetricManifold, args...)
     return Val(:parent)
 end

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -70,7 +70,11 @@ function christoffel_symbols_first(
     @einsum Γ[i, j, k] = 1 / 2 * (∂g[k, j, i] + ∂g[i, k, j] - ∂g[i, j, k])
     return Γ
 end
-@decorator_transparent_signature christoffel_symbols_first(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
+@decorator_transparent_signature christoffel_symbols_first(
+    M::MD,
+    p;
+    kwargs...,
+) where {MD<:AbstractDecoratorManifold}
 
 @doc raw"""
     christoffel_symbols_second(
@@ -100,7 +104,11 @@ function christoffel_symbols_second(
     @einsum Γ₂[l, i, j] = Ginv[k, l] * Γ₁[i, j, k]
     return Γ₂
 end
-@decorator_transparent_signature christoffel_symbols_second(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
+@decorator_transparent_signature christoffel_symbols_second(
+    M::MD,
+    p;
+    kwargs...,
+) where {MD<:AbstractDecoratorManifold}
 
 @doc raw"""
     christoffel_symbols_second_jacobian(
@@ -130,7 +138,11 @@ function christoffel_symbols_second_jacobian(
     )
     return ∂Γ
 end
-@decorator_transparent_signature christoffel_symbols_second_jacobian(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
+@decorator_transparent_signature christoffel_symbols_second_jacobian(
+    M::MD,
+    p;
+    kwargs...,
+) where {MD<:AbstractDecoratorManifold}
 
 Base.copyto!(M::MetricManifold, q, p) = copyto!(M.manifold, q, p)
 Base.copyto!(M::MetricManifold, Y, p, X) = copyto!(M.manifold, Y, p, X)
@@ -498,8 +510,11 @@ function local_metric_jacobian(
     ∂g = reshape(_jacobian(q -> local_metric(M, q), p, backend), n, n, n)
     return ∂g
 end
-@decorator_transparent_signature local_metric_jacobian(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
-
+@decorator_transparent_signature local_metric_jacobian(
+    M::MD,
+    p;
+    kwargs...,
+) where {MD<:AbstractDecoratorManifold}
 
 @doc raw"""
     log(N::MetricManifold{M,G}, p, q)

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -70,7 +70,11 @@ function christoffel_symbols_first(
     @einsum Γ[i, j, k] = 1 / 2 * (∂g[k, j, i] + ∂g[i, k, j] - ∂g[i, j, k])
     return Γ
 end
-@decorator_transparent_signature christoffel_symbols_first(M::AbstractDecoratorManifold, p; kwargs...)
+@decorator_transparent_signature christoffel_symbols_first(
+    M::AbstractDecoratorManifold,
+    p;
+    kwargs...,
+)
 function decorator_transparent_dispatch(
     ::typeof(christoffel_symbols_first),
     ::MetricManifold,
@@ -107,7 +111,11 @@ function christoffel_symbols_second(
     @einsum Γ₂[l, i, j] = Ginv[k, l] * Γ₁[i, j, k]
     return Γ₂
 end
-@decorator_transparent_signature christoffel_symbols_second(M::AbstractDecoratorManifold, p; kwargs...)
+@decorator_transparent_signature christoffel_symbols_second(
+    M::AbstractDecoratorManifold,
+    p;
+    kwargs...,
+)
 function decorator_transparent_dispatch(
     ::typeof(christoffel_symbols_second),
     ::MetricManifold,
@@ -144,7 +152,11 @@ function christoffel_symbols_second_jacobian(
     )
     return ∂Γ
 end
-@decorator_transparent_signature christoffel_symbols_second_jacobian(M::AbstractDecoratorManifold, p; kwargs...)
+@decorator_transparent_signature christoffel_symbols_second_jacobian(
+    M::AbstractDecoratorManifold,
+    p;
+    kwargs...,
+)
 function decorator_transparent_dispatch(
     ::typeof(christoffel_symbols_second_jacobian),
     ::MetricManifold,
@@ -330,7 +342,7 @@ end
 function decorator_transparent_dispatch(
     ::typeof(einstein_tensor),
     ::MetricManifold,
-    args...
+    args...,
 )
     return Val(:parent)
 end
@@ -371,7 +383,12 @@ where $G_p$ is the local matrix representation of `G`, see [`local_metric`](@ref
 """
 flat(::MetricManifold, ::Any...)
 
-@decorator_transparent_fallback function flat!(M::MetricManifold, ξ::CoTFVector, p, X::TFVector)
+@decorator_transparent_fallback function flat!(
+    M::MetricManifold,
+    ξ::CoTFVector,
+    p,
+    X::TFVector,
+)
     g = local_metric(M, p)
     copyto!(ξ.data, g * X.data)
     return ξ
@@ -386,11 +403,15 @@ gaussian_curvature(::Manifold, ::Any)
 function gaussian_curvature(M::Manifold, p; kwargs...)
     return ricci_curvature(M, p; kwargs...) / 2
 end
-@decorator_transparent_signature gaussian_curvature(M::AbstractDecoratorManifold, p; kwargs...)
+@decorator_transparent_signature gaussian_curvature(
+    M::AbstractDecoratorManifold,
+    p;
+    kwargs...,
+)
 function decorator_transparent_dispatch(
     ::typeof(gaussian_curvature),
     ::MetricManifold,
-    args...
+    args...,
 )
     return Val(:parent)
 end
@@ -425,7 +446,7 @@ end
 function decorator_transparent_dispatch(
     ::typeof(inverse_local_metric),
     ::MetricManifold,
-    args...
+    args...,
 )
     return Val(:parent)
 end
@@ -494,7 +515,12 @@ where $G_p$ is the loal matrix representation of the [`Metric`](@ref) `G`.
 """
 inner(::MetricManifold, ::Any)
 
-@decorator_transparent_fallback :intransparent function inner(M::MMT, p, X, Y) where {MMT<:MetricManifold}
+@decorator_transparent_fallback :intransparent function inner(
+    M::MMT,
+    p,
+    X,
+    Y,
+) where {MMT<:MetricManifold}
     return dot(X, local_metric(M, p) * Y)
 end
 function inner(
@@ -517,11 +543,7 @@ where the latter expression uses Einstein summation convention.
 """
 local_metric(::Manifold, ::Any...)
 @decorator_transparent_signature local_metric(M::Manifold, p; kwargs...)
-function decorator_transparent_dispatch(
-    ::typeof(local_metric),
-    ::MetricManifold,
-    args...,
-)
+function decorator_transparent_dispatch(::typeof(local_metric), ::MetricManifold, args...)
     return Val(:parent)
 end
 
@@ -542,7 +564,11 @@ function local_metric_jacobian(M::Manifold, p; backend::AbstractDiffBackend=diff
     ∂g = reshape(_jacobian(q -> local_metric(M, q), p, backend), n, n, n)
     return ∂g
 end
-@decorator_transparent_signature local_metric_jacobian(M::AbstractDecoratorManifold, p; kwargs...)
+@decorator_transparent_signature local_metric_jacobian(
+    M::AbstractDecoratorManifold,
+    p;
+    kwargs...,
+)
 function decorator_transparent_dispatch(
     ::typeof(local_metric_jacobian),
     ::MetricManifold,
@@ -597,11 +623,7 @@ end
 Compute the Ricci scalar curvature of the manifold `M` at the point `p`.
 """
 ricci_curvature(::Manifold, ::Any)
-function ricci_curvature(
-    M::Manifold,
-    p;
-    backend::AbstractDiffBackend=diff_backend(),
-)
+function ricci_curvature(M::Manifold, p; backend::AbstractDiffBackend=diff_backend())
     Ginv = inverse_local_metric(M, p)
     Ric = ricci_tensor(M, p; backend=backend)
     S = sum(Ginv .* Ric)

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -1,8 +1,15 @@
 @doc raw"""
     Metric
 
-Abstract type for the pseudo-Riemannian metric tensor $g$, a family of smoothly
+Abstract type for the pseudo-Riemannian metric tensor ``g``, a family of smoothly
 varying inner products on the tangent space. See [`inner`](@ref).
+
+# Constructors
+
+    Metric(M)
+
+Generate the manifold `M` with the correstponding metric (subtype of this type).
+See also [`MetricManifold`](@ref).
 """
 abstract type Metric end
 
@@ -37,8 +44,8 @@ end
     RiemannianMetric <: Metric
 
 Abstract type for Riemannian metrics, a family of positive definite inner
-products. The positive definite property means that for $X  ∈ T_p \mathcal M$, the
-inner product $g(X, X) > 0$ whenever $X$ is not the zero vector.
+products. The positive definite property means that for ``X  ∈ T_p \mathcal M``, the
+inner product ``g(X, X) > 0`` whenever ``X`` is not the zero vector.
 """
 abstract type RiemannianMetric <: Metric end
 
@@ -52,11 +59,13 @@ abstract type RiemannianMetric <: Metric end
 Compute the Christoffel symbols of the first kind in local coordinates.
 The Christoffel symbols are (in Einstein summation convention)
 
-$Γ_{ijk} = \frac{1}{2} \Bigl[g_{kj,i} + g_{ik,j} - g_{ij,k}\Bigr],$
+```math
+Γ_{ijk} = \frac{1}{2} \Bigl[g_{kj,i} + g_{ik,j} - g_{ij,k}\Bigr],
+```
 
-where $g_{ij,k}=\frac{∂}{∂ p^k} g_{ij}$ is the coordinate
+where ``g_{ij,k}=\frac{∂}{∂ p^k} g_{ij}`` is the coordinate
 derivative of the local representation of the metric tensor. The dimensions of
-the resulting multi-dimensional array are ordered $(i,j,k)$.
+the resulting multi-dimensional array are ordered ``(i,j,k)``.
 """
 christoffel_symbols_first(::Manifold, ::Any)
 function christoffel_symbols_first(
@@ -93,11 +102,13 @@ end
 Compute the Christoffel symbols of the second kind in local coordinates.
 The Christoffel symbols are (in Einstein summation convention)
 
-$Γ^{l}_{ij} = g^{kl} Γ_{ijk},$
+````math
+Γ^{l}_{ij} = g^{kl} Γ_{ijk},
+````
 
-where $Γ_{ijk}$ are the Christoffel symbols of the first kind, and
-$g^{kl}$ is the inverse of the local representation of the metric tensor.
-The dimensions of the resulting multi-dimensional array are ordered $(l,i,j)$.
+where ``Γ_{ijk}`` are the Christoffel symbols of the first kind, and
+``g^{kl}`` is the inverse of the local representation of the metric tensor.
+The dimensions of the resulting multi-dimensional array are ordered ``(l,i,j)``.
 """
 christoffel_symbols_second(::Manifold, ::Any)
 function christoffel_symbols_second(
@@ -126,15 +137,19 @@ end
 
 @doc raw"""
     christoffel_symbols_second_jacobian(
-        M::MetricManifold,
+        M::Manifold,
         p;
         backend::AbstractDiffBackend = diff_backend(),
     )
 
 Get partial derivatives of the Christoffel symbols of the second kind
-for manifold `M` at `p` with respect to the coordinates of `p`,
-$\frac{∂}{∂ p^l} Γ^{k}_{ij} = Γ^{k}_{ij,l}.$
-The dimensions of the resulting multi-dimensional array are ordered $(i,j,k,l)$.
+for manifold `M` at `p` with respect to the coordinates of `p`, i.e.
+
+```math
+\frac{∂}{∂ p^l} Γ^{k}_{ij} = Γ^{k}_{ij,l}.
+```
+
+The dimensions of the resulting multi-dimensional array are ordered ``(i,j,k,l)``.
 """
 christoffel_symbols_second_jacobian(::Manifold, ::Any)
 function christoffel_symbols_second_jacobian(
@@ -308,9 +323,12 @@ function decorator_transparent_dispatch(
 end
 
 @doc raw"""
-    det_local_metric(M::MetricManifold, p)
+    det_local_metric(M::Manifold, p)
 
-Return the determinant of local matrix representation of the metric tensor $g$.
+Return the determinant of local matrix representation of the metric tensor ``g``, i.e. of the
+matrix ``G(p)`` representing the metric in the tangent space at ``p`` with as a matrix.
+
+See also [`local_metric`](@ref)
 """
 det_local_metric(::Manifold, ::Any)
 function det_local_metric(M::Manifold, p)
@@ -325,7 +343,7 @@ function decorator_transparent_dispatch(
     return Val(:parent)
 end
 """
-    einstein_tensor(M::MetricManifold, p; backend::AbstractDiffBackend = diff_backend())
+    einstein_tensor(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
 Compute the Einstein tensor of the manifold `M` at the point `p`.
 """
@@ -379,7 +397,7 @@ computing
 ````math
 X^♭= G_p X,
 ````
-where $G_p$ is the local matrix representation of `G`, see [`local_metric`](@ref)
+where ``G_p`` is the local matrix representation of `G`, see [`local_metric`](@ref)
 """
 flat(::MetricManifold, ::Any...)
 
@@ -395,7 +413,7 @@ flat(::MetricManifold, ::Any...)
 end
 
 """
-    gaussian_curvature(M::MetricManifold, x; backend::AbstractDiffBackend = diff_backend())
+    gaussian_curvature(M::Manifold, x; backend::AbstractDiffBackend = diff_backend())
 
 Compute the Gaussian curvature of the manifold `M` at the point `x`.
 """
@@ -433,10 +451,12 @@ function injectivity_radius(M::MetricManifold, p, m::ExponentialRetraction)
 end
 
 @doc raw"""
-    inverse_local_metric(M::MetricManifold, p)
+    inverse_local_metric(M::Manifold, p)
 
 Return the local matrix representation of the inverse metric (cometric) tensor, usually
-written $g^{ij}$.
+written ``g^{ij}``.
+
+See also [`local_metric`](@ref)
 """
 inverse_local_metric(::Manifold, ::Any)
 function inverse_local_metric(M::Manifold, p)
@@ -511,7 +531,7 @@ otherwise the [`local_metric`](@ref)`(M, p)` is employed as
 ````math
 g_p(X, Y) = ⟨X, G_p Y⟩,
 ````
-where $G_p$ is the loal matrix representation of the [`Metric`](@ref) `G`.
+where ``G_p`` is the loal matrix representation of the [`Metric`](@ref) `G`.
 """
 inner(::MetricManifold, ::Any)
 
@@ -534,11 +554,11 @@ function inner(
 end
 
 @doc raw"""
-    local_metric(M::MetricManifold, p, B)
+    local_metric(M::Manifold, p, B)
 
-Return the local matrix representation at the point `p` of the metric tensor $g$ with
-respect to the [`AbstractBasis`](@ref) `B` on the [`Manifold`](@ref) `M`, usually written $g_{ij}$.
-The matrix has the property that $g(X, Y)=X^\mathrm{T} [g_{ij}] Y = g_{ij} X^i Y^j$,
+Return the local matrix representation at the point `p` of the metric tensor ``g`` with
+respect to the [`AbstractBasis`](@ref) `B` on the [`Manifold`](@ref) `M`, usually written ``g_{ij}``.
+The matrix has the property that ``g(X, Y)=X^\mathrm{T} [g_{ij}] Y = g_{ij} X^i Y^j``,
 where the latter expression uses Einstein summation convention.
 """
 local_metric(::Manifold, ::Any...)
@@ -555,8 +575,8 @@ end
     )
 
 Get partial derivatives of the local metric of `M` at `p` with respect to the
-coordinates of `p`, $\frac{∂}{∂ p^k} g_{ij} = g_{ij,k}$. The
-dimensions of the resulting multi-dimensional array are ordered $(i,j,k)$.
+coordinates of `p`, ``\frac{∂}{∂ p^k} g_{ij} = g_{ij,k}``. The
+dimensions of the resulting multi-dimensional array are ordered ``(i,j,k)``.
 """
 local_metric_jacobian(::Manifold, ::Any)
 function local_metric_jacobian(M::Manifold, p; backend::AbstractDiffBackend=diff_backend())
@@ -591,8 +611,8 @@ log(::MetricManifold, ::Any...)
 @doc raw"""
     log_local_metric_density(M::Manifold, p)
 
-Return the natural logarithm of the metric density $ρ$ of `M` at `p`, which
-is given by $ρ = \log \sqrt{|\det [g_{ij}]|}$.
+Return the natural logarithm of the metric density ``ρ`` of `M` at `p`, which
+is given by ``ρ = \log \sqrt{|\det [g_{ij}]|}``.
 """
 log_local_metric_density(::Manifold, ::Any)
 function log_local_metric_density(M::Manifold, p)
@@ -610,15 +630,16 @@ end
 @doc raw"""
     metric(M::MetricManifold)
 
-Get the metric $g$ of the manifold `M`.
+Get the metric ``g`` of the manifold `M`.
 """
 metric(::MetricManifold)
 
 function metric(M::MetricManifold)
     return M.metric
 end
+
 """
-    ricci_curvature(M::MetricManifold, p; backend::AbstractDiffBackend = diff_backend())
+    ricci_curvature(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
 Compute the Ricci scalar curvature of the manifold `M` at the point `p`.
 """
@@ -638,7 +659,7 @@ function decorator_transparent_dispatch(
     return Val(:parent)
 end
 """
-    ricci_tensor(M::MetricManifold, p; backend::AbstractDiffBackend = diff_backend())
+    ricci_tensor(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
 Compute the Ricci tensor, also known as the Ricci curvature tensor,
 of the manifold `M` at the point `p`.
@@ -656,11 +677,11 @@ function decorator_transparent_dispatch(::typeof(ricci_tensor), ::MetricManifold
     return Val(:parent)
 end
 @doc raw"""
-    riemann_tensor(M::MetricManifold, p; backend::AbstractDiffBackend = diff_backend())
+    riemann_tensor(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
-Compute the Riemann tensor $R^l_{ijk}$, also known as the Riemann curvature
+Compute the Riemann tensor ``R^l_{ijk}``, also known as the Riemann curvature
 tensor, at the point `p`. The dimensions of the resulting multi-dimensional
-array are ordered $(l,i,j,k)$.
+array are ordered ``(l,i,j,k)``.
 """
 riemann_tensor(::Manifold, ::Any...)
 function riemann_tensor(M::Manifold, p; backend::AbstractDiffBackend=diff_backend())
@@ -687,8 +708,8 @@ computing
 ````math
 ξ^♯ = G_p^{-1} ξ,
 ````
-where $G_p$ is the local matrix representation of `G`, i.e. one employs
-[`inverse_local_metric`](@ref) here to obtain $G_p^{-1}$.
+where ``G_p`` is the local matrix representation of `G`, i.e. one employs
+[`inverse_local_metric`](@ref) here to obtain ``G_p^{-1}``.
 """
 sharp(::MetricManifold, ::Any)
 
@@ -717,9 +738,11 @@ Approximate the exponential map on the manifold over the provided timespan
 assuming the Levi-Civita connection by solving the ordinary differential
 equation
 
-$\frac{d^2}{dt^2} p^k + Γ^k_{ij} \frac{d}{dt} p_i \frac{d}{dt} p_j = 0,$
+```math
+\frac{d^2}{dt^2} p^k + Γ^k_{ij} \frac{d}{dt} p_i \frac{d}{dt} p_j = 0,
+```
 
-where $Γ^k_{ij}$ are the Christoffel symbols of the second kind, and
+where ``Γ^k_{ij}`` are the Christoffel symbols of the second kind, and
 the Einstein summation convention is assumed. The arguments `tspan` and
 `solver` follow the `OrdinaryDiffEq` conventions. `kwargs...` specify keyword
 arguments that will be passed to `OrdinaryDiffEq.solve`.

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -59,7 +59,7 @@ derivative of the local representation of the metric tensor. The dimensions of
 the resulting multi-dimensional array are ordered $(i,j,k)$.
 """
 christoffel_symbols_first(::MetricManifold, ::Any)
-@decorator_transparent_function function christoffel_symbols_first(
+function christoffel_symbols_first(
     M::MetricManifold,
     p;
     backend::AbstractDiffBackend=diff_backend(),
@@ -70,6 +70,7 @@ christoffel_symbols_first(::MetricManifold, ::Any)
     @einsum Γ[i, j, k] = 1 / 2 * (∂g[k, j, i] + ∂g[i, k, j] - ∂g[i, j, k])
     return Γ
 end
+@decorator_transparent_signature christoffel_symbols_first(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
 
 @doc raw"""
     christoffel_symbols_second(
@@ -88,7 +89,7 @@ $g^{kl}$ is the inverse of the local representation of the metric tensor.
 The dimensions of the resulting multi-dimensional array are ordered $(l,i,j)$.
 """
 christoffel_symbols_second(::MetricManifold, ::Any)
-@decorator_transparent_function function christoffel_symbols_second(
+function christoffel_symbols_second(
     M::MetricManifold,
     p;
     backend::AbstractDiffBackend=diff_backend(),
@@ -99,6 +100,7 @@ christoffel_symbols_second(::MetricManifold, ::Any)
     @einsum Γ₂[l, i, j] = Ginv[k, l] * Γ₁[i, j, k]
     return Γ₂
 end
+@decorator_transparent_signature christoffel_symbols_second(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
 
 @doc raw"""
     christoffel_symbols_second_jacobian(
@@ -113,7 +115,7 @@ $\frac{∂}{∂ p^l} Γ^{k}_{ij} = Γ^{k}_{ij,l}.$
 The dimensions of the resulting multi-dimensional array are ordered $(i,j,k,l)$.
 """
 christoffel_symbols_second_jacobian(::MetricManifold, ::Any)
-@decorator_transparent_function function christoffel_symbols_second_jacobian(
+function christoffel_symbols_second_jacobian(
     M::MetricManifold,
     p;
     backend::AbstractDiffBackend=diff_backend(),
@@ -128,6 +130,7 @@ christoffel_symbols_second_jacobian(::MetricManifold, ::Any)
     )
     return ∂Γ
 end
+@decorator_transparent_signature christoffel_symbols_second_jacobian(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
 
 Base.copyto!(M::MetricManifold, q, p) = copyto!(M.manifold, q, p)
 Base.copyto!(M::MetricManifold, Y, p, X) = copyto!(M.manifold, Y, p, X)
@@ -486,7 +489,7 @@ coordinates of `p`, $\frac{∂}{∂ p^k} g_{ij} = g_{ij,k}$. The
 dimensions of the resulting multi-dimensional array are ordered $(i,j,k)$.
 """
 local_metric_jacobian(::MetricManifold, ::Any)
-@decorator_transparent_function :intransparent function local_metric_jacobian(
+function local_metric_jacobian(
     M::MetricManifold,
     p;
     backend::AbstractDiffBackend=diff_backend(),
@@ -495,6 +498,8 @@ local_metric_jacobian(::MetricManifold, ::Any)
     ∂g = reshape(_jacobian(q -> local_metric(M, q), p, backend), n, n, n)
     return ∂g
 end
+@decorator_transparent_signature local_metric_jacobian(M::MD, p; kwargs...) where {MD <:AbstractDecoratorManifold}
+
 
 @doc raw"""
     log(N::MetricManifold{M,G}, p, q)

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -345,7 +345,7 @@ end
 """
     einstein_tensor(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
-Compute the Einstein tensor of the manifold `M` at the point `p`.
+Compute the Einstein tensor of the manifold `M` at the point `p`, see [https://en.wikipedia.org/wiki/Einstein_tensor](https://en.wikipedia.org/wiki/Einstein_tensor)
 """
 einstein_tensor(::Manifold, ::Any...)
 function einstein_tensor(M::Manifold, p; backend::AbstractDiffBackend=diff_backend())
@@ -662,7 +662,7 @@ end
     ricci_tensor(M::Manifold, p; backend::AbstractDiffBackend = diff_backend())
 
 Compute the Ricci tensor, also known as the Ricci curvature tensor,
-of the manifold `M` at the point `p`.
+of the manifold `M` at the point `p`, see [https://en.wikipedia.org/wiki/Ricci_curvature#Introduction_and_local_definition](https://en.wikipedia.org/wiki/Ricci_curvature#Introduction_and_local_definition).
 """
 ricci_tensor(::Manifold, ::Any)
 function ricci_tensor(M::Manifold, p; kwargs...)

--- a/test/euclidean.jl
+++ b/test/euclidean.jl
@@ -221,4 +221,29 @@ include("utils.jl")
         embed!(O, q2, p)
         @test q2 == qT
     end
+
+    @testset "Euclidean metric tests" begin
+        M = Euclidean(2)
+        p = zeros(2)
+        C1 = christoffel_symbols_first(M, p)
+        @test size(C1) == (2, 2, 2)
+        @test norm(C1) ≈ 0.0 atol = 1e-13
+        C2 = christoffel_symbols_second(M, p)
+        @test size(C2) == (2, 2, 2)
+        @test norm(C2) ≈ 0.0 atol = 1e-13
+        C2j = christoffel_symbols_second_jacobian(M, p)
+        @test size(C2j) == (2, 2, 2, 2)
+        @test norm(C2j) ≈ 0.0 atol = 1e-16
+        @test einstein_tensor(M, p) == zeros(2, 2)
+        @test ricci_curvature(M, p) ≈ 0 atol = 1e-16
+        RC = ricci_tensor(M, p)
+        @test size(RC) == (2, 2)
+        @test norm(RC) ≈ 0.0 atol = 1e-16
+        @test local_metric(M, p) == Diagonal(ones(2))
+        @test inverse_local_metric(M, p) == Diagonal(ones(2))
+        @test det_local_metric(M, p) == 1
+        RT = riemann_tensor(M, p)
+        @test size(RT) == (2, 2, 2, 2)
+        @test norm(RT) ≈ 0.0 atol = 1e-16
+    end
 end

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -171,8 +171,8 @@ end
         @test base_manifold(M) === E
         @test metric(M) === g
 
-        @test_throws MethodError local_metric_jacobian(E, zeros(3))
-        @test_throws MethodError christoffel_symbols_second_jacobian(E, zeros(3))
+        @test_throws ErrorException local_metric_jacobian(E, zeros(3))
+        @test_throws ErrorException christoffel_symbols_second_jacobian(E, zeros(3))
 
         for vtype in (Vector, MVector{n})
             x, v, w = vtype(randn(n)), vtype(randn(n)), vtype(randn(n))

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -151,7 +151,7 @@ end
     end
     @testset "Local Metric Error message" begin
         M = MetricManifold(BaseManifold{2}(), NotImplementedMetric())
-        @test_throws ErrorException local_metric(M, [3, 4])
+        @test_throws MethodError local_metric(M, [3, 4])
     end
     @testset "scaled Euclidean metric" begin
         n = 3

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -172,7 +172,7 @@ end
         @test metric(M) === g
 
         @test_throws ErrorException local_metric_jacobian(E, zeros(3))
-        @test_throws ErrorException christoffel_symbols_second_jacobian(E, zeros(3))
+        @test_throws MethodError christoffel_symbols_second_jacobian(E, zeros(3))
 
         for vtype in (Vector, MVector{n})
             x, v, w = vtype(randn(n)), vtype(randn(n)), vtype(randn(n))

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -171,7 +171,7 @@ end
         @test base_manifold(M) === E
         @test metric(M) === g
 
-        @test_throws ErrorException local_metric_jacobian(E, zeros(3))
+        @test_throws MethodError local_metric_jacobian(E, zeros(3))
         @test_throws MethodError christoffel_symbols_second_jacobian(E, zeros(3))
 
         for vtype in (Vector, MVector{n})

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -171,8 +171,8 @@ end
         @test base_manifold(M) === E
         @test metric(M) === g
 
-        @test_throws ErrorException local_metric_jacobian(E, zeros(3))
-        @test_throws ErrorException christoffel_symbols_second_jacobian(E, zeros(3))
+        @test_throws MethodError local_metric_jacobian(E, zeros(3))
+        @test_throws MethodError christoffel_symbols_second_jacobian(E, zeros(3))
 
         for vtype in (Vector, MVector{n})
             x, v, w = vtype(randn(n)), vtype(randn(n)), vtype(randn(n))
@@ -389,9 +389,9 @@ end
         @test is_manifold_point(MM, x) === is_manifold_point(M, x)
         @test is_tangent_vector(MM, x, v) === is_tangent_vector(M, x, v)
 
-        @test_throws ErrorException local_metric(MM2, x)
-        @test_throws ErrorException local_metric_jacobian(MM2, x)
-        @test_throws ErrorException christoffel_symbols_second_jacobian(MM2, x)
+        @test_throws MethodError local_metric(MM2, x)
+        @test_throws MethodError local_metric_jacobian(MM2, x)
+        @test_throws MethodError christoffel_symbols_second_jacobian(MM2, x)
         # MM falls back to nondefault error
         @test_throws MethodError projected_distribution(MM, 1, x)
         @test_throws MethodError projected_distribution(MM, 1)


### PR DESCRIPTION
@jlumpe pointed out that

```
using Manifolds
M = MetricManifold(Euclidean(3), EuclideanMetric())
christoffel_symbols_first(M, zeros(3))
```
Throws an error, that `christoffel_symbols_first not implemented on Euclidean(3; field = ℝ)...`.

I was surprised by that and dived a little bit into our dispatch system for Christoffel symbols and their Jacobians.
I think I found the culprit.

In the original code the functions `christoffel_symbols_first`, `christoffel_symbols_second`,  `christoffel_symbols_second_jacobian` and `local_metric_jacobian` where introduced as transparent functions in our decorator system. This meant the following

1. the functions acted completely transparent when called with another decorator (group manifold for example)
2. the original implementation works for non-default metrics
3. the functions acted transparent for default metrics, i.e. falling back to calling `christoffel-symbols_first(M.manifold,...)` for those.

As far as I could see, the default implementation relied on functions that themselves might be transparent or not (`local_metric`, `local_metric_jacobian`,...) but was just a proper implementation for arbitrary metric manifolds anyways. This default implementation did not work for default metrics (as the one above).

So I changed the behaviour to the following: The function is now defined for an arbitrary `MetricManifold`, that is transparent for all others (1. is still valid), but the generic implementation is now called for 2. and 3.
The inner calls are now also working properly (falling back to `local_metric_jacobian` for `Euclidean` when using `MetricManifold(Euclidean(3), EuclideanMetric(3))`.

Now the above example works.

The one point left to discuss is:
The Christoffel functions now still have to be called with `MatricManifold`s, while they would be also valid for `Manifolds` (if one has a default metric in mind). One could try to do something like passing a `::Manifold` based call to the default metric `MetricManifold`. What do you think?

