### PR TITLE
rename `get_point_coordinates` to `get_parameters`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/docs/src/features/atlases.md
+++ b/docs/src/features/atlases.md
@@ -1,17 +1,19 @@
 # [Atlases and charts](@id atlases_and_charts)
 
-Atlases on an ``n``-dimensional manifold $\mathcal M$ are collections of charts ``\mathcal A = \{(U_i, \varphi_i) \colon i \in I\}``, where ``I`` is a (finite or infinte) index family, such that ``U_i \subseteq \mathcal M`` is an open set and each chart ``\varphi_i: U_i \to \mathbb{R}^n`` is a homeomorphism. This means, that ``\varphi_i`` is bijecive – sometimes also called one-to-one and onto - and continuous, and its inverse ``\varphi_i^{-1}`` is continuous as well.
-The inverse ``\varphi_i^{-1}`` is called (local) parametrization.
+Atlases on an ``n``-dimensional manifold $\mathcal M$ are collections of charts ``\mathcal A = \{(U_i, φ_i) \colon i \in I\}``, where ``I`` is a (finite or infinte) index family, such that ``U_i \subseteq \mathcal M`` is an open set and each chart ``φ_i: U_i \to \mathbb{R}^n`` is a homeomorphism. This means, that ``φ_i`` is bijecive – sometimes also called one-to-one and onto - and continuous, and its inverse ``φ_i^{-1}`` is continuous as well.
+The inverse ``φ_i^{-1}`` is called (local) parametrization.
+The resulting _parameters_ ``a=φ(p)`` of ``p`` (with respect to the chart ``φ`` are in the literature also called “(local) coordinates”. To distinguish the parameter ``a`` from  [`get_coordinates`](@ref) in a basis, we use the terminology parameter in this package.
+
 For an atlas ``\mathcal A`` we further require that
 
 ```math
 \displaystyle\bigcup_{i\in I} U_i = \mathcal M.
 ```
 
-We say that ``\varphi_i`` is a chart about ``p``, if ``p\in U_i``.
+We say that ``φ_i`` is a chart about ``p``, if ``p\in U_i``.
 An atlas provides a connection between a manifold and the Euclidean space ``\mathbb{R}^n``, since
 locally, a chart about ``p`` can be used to identify its neighborhood (as long as you stay in ``U_i``) with a subset of a Euclidean space.
-Most manifolds we consider are smooth, i.e. any change of charts ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, where ``i,j\in I``, is a smooth function. These changes of charts are also called transition maps.
+Most manifolds we consider are smooth, i.e. any change of charts ``φ_i \circ φ_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, where ``i,j\in I``, is a smooth function. These changes of charts are also called transition maps.
 
 Most operations on manifolds in `Manifolds.jl` avoid operating in a chart through appropriate embeddings and formulas derived for particular manifolds, though atlases provide the most general way of working with manifolds.
 Compared to these approaches, using an atlas is often more technical and time-consuming.
@@ -23,12 +25,12 @@ There are no type restrictions for indices of charts in atlases.
 Operations using atlases and charts are available through the following functions:
 
 * [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point ``p``. This function should work deterministically, i.e. for a fixed ``p`` always return the same chart.
-* [`get_parameters`](@ref Main.Manifolds.get_parameters) converts a point to its local coordinates, also called parameters with respect to the chart in a chart.
+* [`get_parameters`](@ref Main.Manifolds.get_parameters) converts a point to its parameters with respect to the chart in a chart.
 * [`get_point`](@ref Main.Manifolds.get_point) converts parameters (local coordinates) in a chart to the point that corresponds to them.
-* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``\varphi``.
-* [`transition_map`](@ref Main.Manifolds.transition_map) converts coordinates of a point between two charts, e.g. computes ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``.
+* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``φ``.
+* [`transition_map`](@ref Main.Manifolds.transition_map) converts coordinates of a point between two charts, e.g. computes ``φ_i\circ φ_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``.
 
-While an atlas could store charts as explicit functions, it is favourable, that the [`get_parameters`] actually implements a chart ``\varphi``, [`get_point`](@ref) its inverse, the prametrization ``\varphi^{-1}``.
+While an atlas could store charts as explicit functions, it is favourable, that the [`get_parameters`] actually implements a chart ``φ``, [`get_point`](@ref) its inverse, the prametrization ``φ^{-1}``.
 
 ```@autodocs
 Modules = [Manifolds,ManifoldsBase]

--- a/docs/src/features/atlases.md
+++ b/docs/src/features/atlases.md
@@ -8,13 +8,13 @@ For an atlas ``\mathcal A`` we further require that
 \displaystyle\bigcup_{i\in I} U_i = \mathcal M.
 ```
 
-We say ``\varphi_i`` is a chart about ``p``, if ``p\in U_i``
+We say that ``\varphi_i`` is a chart about ``p``, if ``p\in U_i``.
 An atlas provides a connection between a manifold and the Euclidean space ``\mathbb{R}^n``, since
-locally, a chart about ``p`` can be used to identify its neighborhood (as long as you sta in ``U_i``) “looks like” the Euclidean space.
-Most manifolds we consider are smooth, i.e. any change of charts ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``, is a smooth function. These change of charts are also called transition maps
+locally, a chart about ``p`` can be used to identify its neighborhood (as long as you stay in ``U_i``) with a subset of a Euclidean space.
+Most manifolds we consider are smooth, i.e. any change of charts ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, where ``i,j\in I``, is a smooth function. These changes of charts are also called transition maps.
 
 Most operations on manifolds in `Manifolds.jl` avoid operating in a chart through appropriate embeddings and formulas derived for particular manifolds, though atlases provide the most general way of working with manifolds.
-Compared to these approaches, using an atlas ist often more technical and time-consuming.
+Compared to these approaches, using an atlas is often more technical and time-consuming.
 They are extensively used in metric-related functions on [`MetricManifold`](@ref Main.Manifolds.MetricManifold)s.
 
 Atlases are represented by objects of subtypes of [`AbstractAtlas`](@ref Main.Manifolds.AbstractAtlas).
@@ -22,7 +22,7 @@ There are no type restrictions for indices of charts in atlases.
 
 Operations using atlases and charts are available through the following functions:
 
-* [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point ``p``. This function shoudl work deterministic, i.e. for a fixed ``p`` always return the same chart.
+* [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point ``p``. This function should work deterministically, i.e. for a fixed ``p`` always return the same chart.
 * [`get_parameters`](@ref Main.Manifolds.get_parameters) converts a point to its local coordinates, also called parameters with respect to the chart in a chart.
 * [`get_point`](@ref Main.Manifolds.get_point) converts parameters (local coordinates) in a chart to the point that corresponds to them.
 * [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``\varphi``, by taking the derivative of the coordinate functions ``\varphi^k``, ``k=1,\ldots,n``.

--- a/docs/src/features/atlases.md
+++ b/docs/src/features/atlases.md
@@ -25,7 +25,7 @@ Operations using atlases and charts are available through the following function
 * [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point ``p``. This function should work deterministically, i.e. for a fixed ``p`` always return the same chart.
 * [`get_parameters`](@ref Main.Manifolds.get_parameters) converts a point to its local coordinates, also called parameters with respect to the chart in a chart.
 * [`get_point`](@ref Main.Manifolds.get_point) converts parameters (local coordinates) in a chart to the point that corresponds to them.
-* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``\varphi``, by taking the derivative of the coordinate functions ``\varphi^k``, ``k=1,\ldots,n``.
+* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``\varphi``.
 * [`transition_map`](@ref Main.Manifolds.transition_map) converts coordinates of a point between two charts, e.g. computes ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``.
 
 While an atlas could store charts as explicit functions, it is favourable, that the [`get_parameters`] actually implements a chart ``\varphi``, [`get_point`](@ref) its inverse, the prametrization ``\varphi^{-1}``.

--- a/docs/src/features/atlases.md
+++ b/docs/src/features/atlases.md
@@ -1,9 +1,20 @@
 # [Atlases and charts](@id atlases_and_charts)
 
-Atlases on an $n$-dimensional manifold $\mathcal M$ are collections of charts $\{(U_i, \varphi_i) \colon i \in I\}$ such that $U_i \subseteq \mathcal M$ and each chart $\varphi_i$ is a function from $U_i$ to $\mathbb{R}^n$.
-They provide a basic connection between manifolds and Euclidean spaces.
+Atlases on an ``n``-dimensional manifold $\mathcal M$ are collections of charts ``\mathcal A = \{(U_i, \varphi_i) \colon i \in I\}``, where ``I`` is a (finite or infinte) index family, such that ``U_i \subseteq \mathcal M`` is an open set and each chart ``\varphi_i: U_i \to \mathbb{R}^n`` is a homeomorphism. This means, that ``\varphi_i`` is bijecive – sometimes also called one-to-one and onto - and continuous, and its inverse ``\varphi_i^{-1}`` is continuous as well.
+The inverse ``\varphi_i^{-1}`` is called (local) parametrization.
+For an atlas ``\mathcal A`` we further require that
+
+```math
+\displaystyle\bigcup_{i\in I} U_i = \mathcal M.
+```
+
+We say ``\varphi_i`` is a chart about ``p``, if ``p\in U_i``
+An atlas provides a connection between a manifold and the Euclidean space ``\mathbb{R}^n``, since
+locally, a chart about ``p`` can be used to identify its neighborhood (as long as you sta in ``U_i``) “looks like” the Euclidean space.
+Most manifolds we consider are smooth, i.e. any change of charts ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``, is a smooth function. These change of charts are also called transition maps
 
 Most operations on manifolds in `Manifolds.jl` avoid operating in a chart through appropriate embeddings and formulas derived for particular manifolds, though atlases provide the most general way of working with manifolds.
+Compared to these approaches, using an atlas ist often more technical and time-consuming.
 They are extensively used in metric-related functions on [`MetricManifold`](@ref Main.Manifolds.MetricManifold)s.
 
 Atlases are represented by objects of subtypes of [`AbstractAtlas`](@ref Main.Manifolds.AbstractAtlas).
@@ -11,11 +22,13 @@ There are no type restrictions for indices of charts in atlases.
 
 Operations using atlases and charts are available through the following functions:
 
-* [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point.
-* [`get_point_coordinates`](@ref Main.Manifolds.get_point_coordinates) converts a point to its coordinates in a chart.
-* [`get_point`](@ref Main.Manifolds.get_point) converts coordinates in a chart to the point that corresponds to them.
-* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart.
-* [`transition_map`](@ref Main.Manifolds.transition_map) converts coordinates of a point between two charts.
+* [`get_chart_index`](@ref Main.Manifolds.get_chart_index) can be used to select an appropriate chart for the neighborhood of a given point ``p``. This function shoudl work deterministic, i.e. for a fixed ``p`` always return the same chart.
+* [`get_parameters`](@ref Main.Manifolds.get_parameters) converts a point to its local coordinates, also called parameters with respect to the chart in a chart.
+* [`get_point`](@ref Main.Manifolds.get_point) converts parameters (local coordinates) in a chart to the point that corresponds to them.
+* [`induced_basis`](@ref Main.Manifolds.induced_basis) returns a basis of a given vector space at a point induced by a chart ``\varphi``, by taking the derivative of the coordinate functions ``\varphi^k``, ``k=1,\ldots,n``.
+* [`transition_map`](@ref Main.Manifolds.transition_map) converts coordinates of a point between two charts, e.g. computes ``\varphi_i\circ\varphi_j^{-1}: \mathbb{R}^n\to\mathbb{R}^n``, ``i,j\in I``.
+
+While an atlas could store charts as explicit functions, it is favourable, that the [`get_parameters`] actually implements a chart ``\varphi``, [`get_point`](@ref) its inverse, the prametrization ``\varphi^{-1}``.
 
 ```@autodocs
 Modules = [Manifolds,ManifoldsBase]

--- a/docs/src/features/atlases.md
+++ b/docs/src/features/atlases.md
@@ -2,7 +2,7 @@
 
 Atlases on an ``n``-dimensional manifold $\mathcal M$ are collections of charts ``\mathcal A = \{(U_i, φ_i) \colon i \in I\}``, where ``I`` is a (finite or infinte) index family, such that ``U_i \subseteq \mathcal M`` is an open set and each chart ``φ_i: U_i \to \mathbb{R}^n`` is a homeomorphism. This means, that ``φ_i`` is bijecive – sometimes also called one-to-one and onto - and continuous, and its inverse ``φ_i^{-1}`` is continuous as well.
 The inverse ``φ_i^{-1}`` is called (local) parametrization.
-The resulting _parameters_ ``a=φ(p)`` of ``p`` (with respect to the chart ``φ`` are in the literature also called “(local) coordinates”. To distinguish the parameter ``a`` from  [`get_coordinates`](@ref) in a basis, we use the terminology parameter in this package.
+The resulting _parameters_ ``a=φ(p)`` of ``p`` (with respect to the chart ``φ``) are in the literature also called “(local) coordinates”. To distinguish the parameter ``a`` from  [`get_coordinates`](@ref) in a basis, we use the terminology parameter in this package.
 
 For an atlas ``\mathcal A`` we further require that
 

--- a/docs/src/misc/notation.md
+++ b/docs/src/misc/notation.md
@@ -12,7 +12,7 @@ Within the documented functions, the utf8 symbols are used whenever possible, as
 | ``\tau_p`` | action map by group element ``p`` | ``\mathrm{L}_p``, ``\mathrm{R}_p`` | either left or right |
 | ``\times`` | Cartesian product of two manifolds | | see [`ProductManifold`](@ref) |
 | ``^{\wedge}`` | (n-ary) Cartesian power of a manifold | | see [`PowerManifold`](@ref) |
-| ``a`` | coordinates of a point in a chart | | see [`get_point_coordinates`](@ref) |
+| ``a`` | coordinates of a point in a chart | | see [`get_parameters`](@ref) |
 | ``\frac{\mathrm{D}}{\mathrm{d}t}`` | covariant derivative of a vector field ``X(t)`` | | |
 | ``T^*_p \mathcal M`` | the cotangent space at ``p`` | | |
 | ``ξ`` | a cotangent vector from ``T^*_p \mathcal M`` | ``ξ_1, ξ_2,… ,η,\zeta`` | sometimes written with base point ``ξ_p``. |

--- a/docs/src/misc/notation.md
+++ b/docs/src/misc/notation.md
@@ -47,6 +47,7 @@ Within the documented functions, the utf8 symbols are used whenever possible, as
 | ``X`` | a tangent vector from ``T_p \mathcal M`` | ``X_1,X_2,\ldots,Y,Z`` | sometimes written with base point ``X_p`` |
 | ``\operatorname{tr}`` | trace (of a matrix) | |
 | ``\cdot^\mathrm{T}`` | transposed | |
+| ``e_i \in \mathbb R^n`` | the ``i``th unit vector | ``e_i^n`` | the space dimension (``n``) is omited, when clear from context
 | ``B`` | a vector bundle | |
 | ``\mathcal T_{q\gets p}X`` | vector transport | | of the vector ``X`` from ``T_p\mathcal M`` to ``T_q\mathcal M``
 | ``\mathcal T_{p,Y}X`` | vector transport in direction ``Y`` | | of the vector ``X`` from ``T_p\mathcal M`` to ``T_q\mathcal M``, where ``q`` is deretmined by ``Y``, for example using the exponential map or some retraction.

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -583,6 +583,6 @@ export AbstractDiffBackend,
     AbstractRiemannianDiffBackend, FiniteDifferencesBackend, RiemannianONBDiffBackend
 export diff_backend, diff_backend!, diff_backends
 # atlases and charts
-export get_point, get_point!, get_point_coordinates, get_point_coordinates!
+export get_point, get_point!, get_parameters, get_parameters!
 
 end # module

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -161,7 +161,7 @@ We have ``i_{\text{from}}\in I``, ``i_{\text{to}}\in J``.
 
 This method then computes
 ```math
-\bigl(\psi{i_{\text{to}}}\circ φ_{i_{\text{from}}}^{-1}\bigr)(a)
+\bigl(\psi_{i_{\text{to}}}\circ φ_{i_{\text{from}}}^{-1}\bigr)(a)
 ```
 
 Note that, similarly to [`get_parameters`](@ref), this method should fail the same way if ``V_{i_{\text{to}}}\cap U_{i_{\text{from}}}=\emptyset``.
@@ -246,16 +246,16 @@ end
 The basis induced by chart with index `i` from an [`AbstractAtlas`](@ref) `A` of vector
 space of type `vs`.
 
-For the `vs` a `TangentSpace` this works as  follows:
+For the `vs` a [`TangentSpace`](@ref) this works as  follows:
 
 Let ``n`` denote the dimension of the manifold ``\mathcal M``.
 
 Let the parameter ``a=φ_i(p) ∈ \mathbb R^n`` and ``j∈\{1,…,n\}``.
 We can look at the ``j``th parameter curve ``b_j(t) = a + te_j``, where ``e_j`` denotes the ``j``th unit vector.
-Using the parametrisation we obtain a curve ``c_i(t) = φ^{-1}(b_j(t))`` which fulfills ``c(0) = p``.
+Using the parametrisation we obtain a curve ``c_j(t) = φ_i^{-1}(b_j(t))`` which fulfills ``c(0) = p``.
 
 Now taking the derivative(s) with respect to ``t`` (and evaluate at ``t=0``),
-we obtain a tangent vector for each `corresponding to an equivalence class of curves (having the same derivative) as
+we obtain a tangent vector for each ``j`` corresponding to an equivalence class of curves (having the same derivative) as
 
 ```math
 X_j = [c_j] = \frac{\mathrm{d}}{\mathrm{d}t} c_i(t) \Bigl|_{t=0}

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -18,10 +18,10 @@ abstract type AbstractAtlas{𝔽} end
 
 An atlas indexed by points on a manifold, ``\mathcal M = I`` and parameters (local coordinates)
 are given in ``T_p\mathcal M``.
-This means that a chart ``\varphi_p = \mathrm{cord}\circ\mathrm{retr}_p^{-1}`` is only locally
+This means that a chart ``φ_p = \mathrm{cord}\circ\mathrm{retr}_p^{-1}`` is only locally
 defined (around ``p``), where ``\mathrm{cord}`` is the decomposition of the tangent vector
 into coordinates with respect to the given basis of the tangent space, cf. [`get_coordinates`](@ref).
-The parametrization is given by ``\varphi_p^{-1}=\mathrm{retr}_p\circ\mathrm{vec}``,
+The parametrization is given by ``φ_p^{-1}=\mathrm{retr}_p\circ\mathrm{vec}``,
 where ``\mathrm{vec}`` turns the basis coordinates into a tangent vector, cf. [`get_vector`](@ref).
 
 In short: The coordinates with respect to a basis are used together with a retraction as a parametrization.
@@ -69,7 +69,7 @@ end
 
 Calculate parameters (local coordinates) of point `p` on manifold `M` in chart from an [`AbstractAtlas`](@ref)
 `A` at index `i`.
-This function is hence an implementation of the chart ``\varphi_i(p), i\in I``.
+This function is hence an implementation of the chart ``φ_i(p), i\in I``.
 The parameters are in the number system determined by `A`.
 If the point ``p\notin U_i`` is not in the domain of the chart, this method should throw an error.
 
@@ -104,7 +104,7 @@ end
 
 Calculate point at parameters (local coordinates) `a` on manifold `M` in chart from
 an [`AbstractAtlas`](@ref) `A` at index `i`.
-This function is hence an implementation of the inverse ``\varphi_i^{-1}(a), i\in I`` of a chart, also called a parametrization.
+This function is hence an implementation of the inverse ``φ_i^{-1}(a), i\in I`` of a chart, also called a parametrization.
 
 # See also
 
@@ -155,13 +155,13 @@ coordinates of that point in chart `(A_to, i_to)`. If `A_from` and `A_to` are eq
 can be omitted.
 
 Mathematically this function is the transition map or change of charts, but it
-might even be between two atlases ``A_{\text{from}} = \{(U_i,\varphi_i)\}_{i\in I} `` and ``A_{\text{to}} = \{(V_j,\psi_j)\}_{j\in J}``,
+might even be between two atlases ``A_{\text{from}} = \{(U_i,φ_i)\}_{i\in I} `` and ``A_{\text{to}} = \{(V_j,\psi_j)\}_{j\in J}``,
 and hence ``I, J`` are their index sets.
 We have ``i_{\text{from}}\in I``, ``i_{\text{to}}\in J``.
 
 This method then computes
 ```math
-\bigl(\psi{i_{\text{to}}}\circ\varphi_{i_{\text{from}}}^{-1}\bigr)(a)
+\bigl(\psi{i_{\text{to}}}\circ φ_{i_{\text{from}}}^{-1}\bigr)(a)
 ```
 
 Note that, similarly to [`get_parameters`](@ref), this method should fail the same way if ``V_{i_{\text{to}}}\cap U_{i_{\text{from}}}=\emptyset``.
@@ -244,8 +244,10 @@ end
     InducedBasis(vs::VectorSpaceType, A::AbstractAtlas, i)
 
 The basis induced by chart with index `i` from an [`AbstractAtlas`](@ref) `A` of vector
-space of type `vs`, i.e. if you write the chart ``\varphi_i = (\varphi_i^1,...,\varphi_n^1)^{\mathrm{T}}``.
-as its coordinate functions, then the basis consists of the partial derivatives ``\Bigl(\frac{\partial}{\partial\varphi_i^j}\Bigr)_p``.
+space of type `vs`.
+This follows
+, i.e. if you write the chart ``φ_i = (φ_i^1,...,φ_n^1)^{\mathrm{T}}``.
+as its coordinate functions, then the basis consists of the partial derivatives ``\Bigl(\frac{\partial}{\partialφ_i^j}\Bigr)_p``.
 
 
 # See also

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -18,7 +18,7 @@ abstract type AbstractAtlas{𝔽} end
 
 An atlas indexed by points on a manifold, ``\mathcal M = I`` and parameters (local coordinates)
 are given in ``T_p\mathcal M``.
-This means, that a chart ``\varphi_p = \mathrm{cord}\circ\mathrm{retr}_p^{-1}`` is only locally
+This means that a chart ``\varphi_p = \mathrm{cord}\circ\mathrm{retr}_p^{-1}`` is only locally
 defined (around ``p``), where ``\mathrm{cord}`` is the decomposition of the tangent vector
 into coordinates with respect to the given basis of the tangent space, cf. [`get_coordinates`](@ref).
 The parametrization is given by ``\varphi_p^{-1}=\mathrm{retr}_p\circ\mathrm{vec}``,
@@ -69,9 +69,9 @@ end
 
 Calculate parameters (local coordinates) of point `p` on manifold `M` in chart from an [`AbstractAtlas`](@ref)
 `A` at index `i`.
-This function is hence animplementation chart ``\varphi_i(p), i\in I``.
+This function is hence an implementation of the chart ``\varphi_i(p), i\in I``.
 The parameters are in the number system determined by `A`.
-If the point ``p\notin U_i`` is not in the domain of the chart, this method shoudl throw an error.
+If the point ``p\notin U_i`` is not in the domain of the chart, this method should throw an error.
 
 # See also
 
@@ -155,7 +155,7 @@ coordinates of that point in chart `(A_to, i_to)`. If `A_from` and `A_to` are eq
 can be omitted.
 
 Mathematically this function is the transition map or change of charts, but it
-might even be between to atlasses ``A_{\text{from}} = \{(U_i,\varphi_i)\}_{i\in I} `` and ``A_{\text{to}} = \{(V_j,\psi_j)\}_{j\in J}``,
+might even be between two atlases ``A_{\text{from}} = \{(U_i,\varphi_i)\}_{i\in I} `` and ``A_{\text{to}} = \{(V_j,\psi_j)\}_{j\in J}``,
 and hence ``I, J`` are their index sets.
 We have ``i_{\text{from}}\in I``, ``i_{\text{to}}\in J`` and this method computes
 
@@ -164,7 +164,7 @@ This method then computes
 \bigl(\psi{i_{\text{to}}}\circ\varphi_{i_{\text{from}}}^{-1}\bigr)(a)
 ```
 
-Note that, similar to [`get_parameters`](@ref) this method should fail the same way if ``V_{i_{\text{to}}}\cap U_{i_{\text{from}}}=\emptyset``.
+Note that, similarly to [`get_parameters`](@ref), this method should fail the same way if ``V_{i_{\text{to}}}\cap U_{i_{\text{from}}}=\emptyset``.
 
 # See also
 

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -157,7 +157,7 @@ can be omitted.
 Mathematically this function is the transition map or change of charts, but it
 might even be between two atlases ``A_{\text{from}} = \{(U_i,\varphi_i)\}_{i\in I} `` and ``A_{\text{to}} = \{(V_j,\psi_j)\}_{j\in J}``,
 and hence ``I, J`` are their index sets.
-We have ``i_{\text{from}}\in I``, ``i_{\text{to}}\in J`` and this method computes
+We have ``i_{\text{from}}\in I``, ``i_{\text{to}}\in J``.
 
 This method then computes
 ```math

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -245,10 +245,23 @@ end
 
 The basis induced by chart with index `i` from an [`AbstractAtlas`](@ref) `A` of vector
 space of type `vs`.
-This follows
-, i.e. if you write the chart ``φ_i = (φ_i^1,...,φ_n^1)^{\mathrm{T}}``.
-as its coordinate functions, then the basis consists of the partial derivatives ``\Bigl(\frac{\partial}{\partialφ_i^j}\Bigr)_p``.
 
+For the `vs` a `TangentSpace` this works as  follows:
+
+Let ``n`` denote the dimension of the manifold ``\mathcal M``.
+
+Let the parameter ``a=φ_i(p) ∈ \mathbb R^n`` and ``j∈\{1,…,n\}``.
+We can look at the ``j``th parameter curve ``b_j(t) = a + te_j``, where ``e_j`` denotes the ``j``th unit vector.
+Using the parametrisation we obtain a curve ``c_i(t) = φ^{-1}(b_j(t))`` which fulfills ``c(0) = p``.
+
+Now taking the derivative(s) with respect to ``t`` (and evaluate at ``t=0``),
+we obtain a tangent vector for each `corresponding to an equivalence class of curves (having the same derivative) as
+
+```math
+X_j = [c_j] = \frac{\mathrm{d}}{\mathrm{d}t} c_i(t) \Bigl|_{t=0}
+```
+
+and the set ``\{X_1,\ldots,X_n\}`` is the chart-induced basis of ``T_p\mathcal M``.
 
 # See also
 

--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -21,7 +21,7 @@ are given in ``T_p\mathcal M``.
 This means, that a chart ``\varphi_p = \mathrm{cord}\circ\mathrm{retr}_p^{-1}`` is only locally
 defined (around ``p``), where ``\mathrm{cord}`` is the decomposition of the tangent vector
 into coordinates with respect to the given basis of the tangent space, cf. [`get_coordinates`](@ref).
-The parametrization is given by ``\varphi_^{-1}=\mathrm{retr}_p\circ\mathrm{vec}``,
+The parametrization is given by ``\varphi_p^{-1}=\mathrm{retr}_p\circ\mathrm{vec}``,
 where ``\mathrm{vec}`` turns the basis coordinates into a tangent vector, cf. [`get_vector`](@ref).
 
 In short: The coordinates with respect to a basis are used together with a retraction as a parametrization.

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -482,13 +482,7 @@ function get_chart_index(::Sphere{n,ℝ}, ::StereographicAtlas, p) where {n}
     end
 end
 
-function get_point_coordinates!(
-    ::Sphere{n,ℝ},
-    x,
-    ::StereographicAtlas,
-    i::Symbol,
-    p,
-) where {n}
+function get_parameters!(::Sphere{n,ℝ}, x, ::StereographicAtlas, i::Symbol, p) where {n}
     if i === :north
         return x .= p[2:end] ./ (1 + p[1])
     else
@@ -533,7 +527,7 @@ function get_vector!(
     X,
     B::InducedBasis{ℝ,TangentSpaceType,<:StereographicAtlas},
 ) where {n}
-    a = get_point_coordinates(M, B.A, B.i, p)
+    a = get_parameters(M, B.A, B.i, p)
     mult = inv(1 + dot(a, a))^2
 
     Y[1] = 0
@@ -561,6 +555,6 @@ function local_metric(
     p,
     B::InducedBasis{ℝ,TangentSpaceType,StereographicAtlas,Symbol},
 ) where {n}
-    a = get_point_coordinates(M, B.A, B.i, p)
+    a = get_parameters(M, B.A, B.i, p)
     return (4 / (1 + dot(a, a))^2) * I
 end

--- a/src/tests/tests_general.jl
+++ b/src/tests/tests_general.jl
@@ -318,13 +318,13 @@ function test_manifold(
         end
         for A in test_atlases
             i = get_chart_index(M, A, pts[1])
-            a = get_point_coordinates(M, A, i, pts[1])
+            a = get_parameters(M, A, i, pts[1])
             Test.@test isa(a, AbstractVector)
             Test.@test length(a) == manifold_dimension(M)
             Test.@test isapprox(M, pts[1], get_point(M, A, i, a))
             if is_mutating
-                get_point_coordinates!(M, a, A, i, pts[2])
-                Test.@test a ≈ get_point_coordinates(M, A, i, pts[2])
+                get_parameters!(M, a, A, i, pts[2])
+                Test.@test a ≈ get_parameters(M, A, i, pts[2])
 
                 q = allocate(pts[1])
                 get_point!(M, q, A, i, a)

--- a/test/power_manifold.jl
+++ b/test/power_manifold.jl
@@ -387,7 +387,7 @@ Random.seed!(42)
         p = [zeros(2), ones(2)]
         X = [ones(2), 2 .* ones(2)]
         A = RetractionAtlas()
-        a = get_point_coordinates(M, A, p, p)
+        a = get_parameters(M, A, p, p)
         p2 = get_point(M, A, p, a)
         @test all(p2 .== p)
     end

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -602,7 +602,7 @@ end
         p = ProductRepr(zeros(2), ones(2))
         X = ProductRepr(ones(2), 2 .* ones(2))
         A = RetractionAtlas()
-        a = get_point_coordinates(M, A, p, p)
+        a = get_parameters(M, A, p, p)
         p2 = get_point(M, A, p, a)
         @test all(p2.parts .== p.parts)
     end

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -176,7 +176,7 @@ using ManifoldsBase: TFVector
             p *= k
             i = Manifolds.get_chart_index(M, A, p)
             @test i === (p[1] < 0 ? :south : :north)
-            a = get_point_coordinates(M, A, i, p)
+            a = get_parameters(M, A, i, p)
             q = get_point(M, A, i, a)
             @test isapprox(M, p, q)
 


### PR DESCRIPTION
I renamed the function according to our discussion (closes #370).
I also added a few more details to the docs concerning atlasess.
Especially, since I had to think about that for a moment myself, I added how charts and parametrizations look like for the `RetractionAtlas`.

I noticed a small caveat, that I currently did not add, since it might really be just a technical remark.
In the `transition_map`, if one chooses `A_from` and `A_to` such that their union is not an atlas, i.e. they are not compatible, then they represent a different structure and in the new parametrisation – informally said – smoothness on `M` might be different.