### PR TITLE
Ensure eigenvalues are positive in SPD matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLinearAffine.jl
@@ -49,7 +49,7 @@ exp(::SymmetricPositiveDefinite, ::Any...)
 function exp!(::SymmetricPositiveDefinite{N}, q, p, X) where {N}
     e = eigen(Symmetric(p))
     U = e.vectors
-    S = e.values
+    S = max.(e.values, floatmin(eltype(e.values)))
     Ssqrt = Diagonal(sqrt.(S))
     SsqrtInv = Diagonal(1 ./ sqrt.(S))
     pSqrt = Symmetric(U * Ssqrt * transpose(U))
@@ -165,7 +165,7 @@ log(::SymmetricPositiveDefinite, ::Any...)
 function log!(M::SymmetricPositiveDefinite{N}, X, p, q) where {N}
     e = eigen(Symmetric(p))
     U = e.vectors
-    S = e.values
+    S = max.(e.values, floatmin(eltype(e.values)))
     Ssqrt = Diagonal(sqrt.(S))
     SsqrtInv = Diagonal(1 ./ sqrt.(S))
     pSqrt = Symmetric(U * Ssqrt * transpose(U))
@@ -215,8 +215,8 @@ function vector_transport_to!(
     distance(M, p, q) < 2 * eps(eltype(p)) && copyto!(Y, X)
     e = eigen(Symmetric(p))
     U = e.vectors
-    S = e.values
-    Ssqrt = sqrt.(e.values)
+    S = max.(e.values, floatmin(eltype(e.values)))
+    Ssqrt = sqrt.(S)
     SsqrtInv = Diagonal(1 ./ Ssqrt)
     Ssqrt = Diagonal(Ssqrt)
     pSqrt = Symmetric(U * Ssqrt * transpose(U)) # p^1/2
@@ -224,7 +224,7 @@ function vector_transport_to!(
     tv = Symmetric(pSqrtInv * X * pSqrtInv) # p^(-1/2)Xp^{-1/2}
     ty = Symmetric(pSqrtInv * q * pSqrtInv) # p^(-1/2)qp^(-1/2)
     e2 = eigen(ty)
-    Se = Diagonal(log.(e2.values))
+    Se = Diagonal(log.(max.(e2.values, floatmin(eltype(e2.values)))))
     Ue = e2.vectors
     logty = Symmetric(Ue * Se * transpose(Ue)) # nearly log_pq without the outer p^1/2
     e3 = eigen(logty) # since they cancel with the pInvSqrt in the next line


### PR DESCRIPTION
By definition symmetric positive definite matrices have positive eigenvalues. Numerical errors may result in infinitesimal negative eigenvalues being computed, resulting in DomainErrors when the sqrt or log of the eigenvalue is calculated.

This change replaces any negative eigenvalues with the smallest positive value to ensure that the sqrt is successful.

This makes it the user's responsibility to ensure that input arguments are valid SPDs before
passing.

This is similar logic to https://github.com/JuliaManifolds/ManifoldsBase.jl/pull/68 