### PR TITLE
Make format action suggest formatting changes

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,8 +16,10 @@ jobs:
           version: 1
       - name: Install JuliaFormatter and format
         run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format("."; verbose=true)'
+          using Pkg
+          Pkg.add(PackageSpec(name="JuliaFormatter"))
+          using JuliaFormatter
+          format("."; verbose=true)
         shell: julia --color=yes {0}
       - name: Suggest formatting changes
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,22 +13,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.4
+          version: 1
       - name: Install JuliaFormatter and format
         run: |
           julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(".")'
-      - name: Check format
-        run: |
-          julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "The following files have not been formatted:"
-              write(stdout, out)
-              out_diff = Cmd(`git diff`) |> read |> String
-              @error "Diff:"
-              write(stdout, out_diff)
-              exit(1)
-          end'
+          julia  -e 'using JuliaFormatter; format("."; verbose=true)'
+        shell: julia --color=yes {0}
+      - name: Suggest formatting changes
+        uses: reviewdog/action-suggester@v1
+        if: github.event_name == 'pull_request'
+        with:
+          tool_name: JuliaFormatter
+          fail_on_error: true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,10 @@ include("utils.jl")
       "Testing Static:   $(TEST_STATIC_SIZED)\n\n" *
       "Check test/utils.jl if you wish to change these settings."
 
+function foo(x)
+return x
+end
+
 @testset "Manifolds.jl" begin
     include_test("differentiation.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,6 @@ include("utils.jl")
       "Testing Static:   $(TEST_STATIC_SIZED)\n\n" *
       "Check test/utils.jl if you wish to change these settings."
 
-function foo(x)
-return x
-end
-
 @testset "Manifolds.jl" begin
     include_test("differentiation.jl")
 


### PR DESCRIPTION
This PR adapts DynamicPPL's convenient [format action](https://github.com/TuringLang/DynamicPPL.jl/blob/master/.github/workflows/Format.yml), which uses the diff generated from running the formatter to review the code and suggest formatting changes, which is more more handy than just telling the author to go run JuliaFormatter.