### PR TITLE
Introduce an ApproximateLogarithmicMap.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ["1.4", "1.5", "~1.6.0-0"]
+        julia-version: ["1.4", "1.6"]
         os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@v2
@@ -27,4 +27,4 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: false
-        if: ${{ matrix.julia-version == '1.5' && matrix.os =='ubuntu-latest' }}
+        if: ${{ matrix.julia-version == '1.6' && matrix.os =='ubuntu-latest' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -379,6 +379,7 @@ export AbstractRetractionMethod,
     PowerRetraction
 export AbstractInverseRetractionMethod,
     ApproximateInverseRetraction,
+    ApproximateLogarithmicMap,
     LogarithmicInverseRetraction,
     QRInverseRetraction,
     PolarInverseRetraction,

--- a/src/manifolds/StiefelCanonicalMetric.jl
+++ b/src/manifolds/StiefelCanonicalMetric.jl
@@ -156,7 +156,7 @@ function inverse_retract!(
     X,
     p,
     q,
-    a::ApproximateInverseRetraction,
+    a::ApproximateLogarithmicMap,
 ) where {n,k}
     M = p' * q
     QR = qr(q - p * M)

--- a/src/manifolds/StiefelCanonicalMetric.jl
+++ b/src/manifolds/StiefelCanonicalMetric.jl
@@ -20,7 +20,7 @@ An approximate implementation of the logarithmic map, which is an [`inverse_retr
 See [`inverse_retract(::MetricManifold{ℝ,Stiefel{n,k,ℝ},CanonicalMetric}, ::Any, ::Any, ::ApproximateLogarithmicMap) where {n,k}`](@ref) for a use case.
 """
 struct ApproximateLogarithmicMap{T} <: ApproximateInverseRetraction
-    max_iterations::T
+    max_iterations::Int
     tolerance::T
 end
 

--- a/src/manifolds/StiefelCanonicalMetric.jl
+++ b/src/manifolds/StiefelCanonicalMetric.jl
@@ -18,6 +18,12 @@ struct CanonicalMetric <: RiemannianMetric end
 
 An approximate implementation of the logarithmic map, which is an [`inverse_retract`](@ref)ion.
 See [`inverse_retract(::MetricManifold{ℝ,Stiefel{n,k,ℝ},CanonicalMetric}, ::Any, ::Any, ::ApproximateLogarithmicMap) where {n,k}`](@ref) for a use case.
+
+# Fields
+
+* `max_iterations` – maximal number of iterations used in the approximation
+* `tolerance` – a tolerance used as a stopping criterion
+
 """
 struct ApproximateLogarithmicMap{T} <: ApproximateInverseRetraction
     max_iterations::Int
@@ -125,7 +131,7 @@ function log(
     M::MetricManifold{ℝ,Stiefel{n,k,ℝ},CanonicalMetric},
     p,
     q;
-    maxiter=1e5,
+    maxiter::Int=10000,
     tolerance=1e-9,
 ) where {n,k}
     X = allocate_result(M, log, p, q)
@@ -138,7 +144,7 @@ function log!(
     X,
     p,
     q;
-    maxiter=1e5,
+    maxiter::Int=10000,
     tolerance=1e-9,
 ) where {n,k}
     inverse_retract!(M, X, p, q, ApproximateLogarithmicMap(maxiter, tolerance))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,8 @@ include("utils.jl")
     include_test("differentiation.jl")
 
     @testset "Ambiguities" begin
-        # TODO: reduce the number of ambiguities for Julia 1.6
         if VERSION.prerelease == () && !Sys.iswindows() && VERSION < v"1.6.0"
-            @test length(Test.detect_ambiguities(ManifoldsBase)) <= 65
+            @test length(Test.detect_ambiguities(ManifoldsBase)) <= 66
             @test length(Test.detect_ambiguities(Manifolds)) == 0
             @test length(our_base_ambiguities()) <= 24
         else

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -313,5 +313,8 @@ using Manifolds: default_metric_dispatch
         s = exp(M4, p, Z)
         Z2 = log(M4, p, s)
         @test isapprox(M4, p, Z, Z2)
+        Z3 = simliar(Z2)
+        log!(M4, Z3, p, s)
+        @test isapprox(M4, p, Z2, Z3)
     end
 end

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -313,7 +313,7 @@ using Manifolds: default_metric_dispatch
         s = exp(M4, p, Z)
         Z2 = log(M4, p, s)
         @test isapprox(M4, p, Z, Z2)
-        Z3 = simliar(Z2)
+        Z3 = similar(Z2)
         log!(M4, Z3, p, s)
         @test isapprox(M4, p, Z2, Z3)
     end


### PR DESCRIPTION
Refactor the one approximate algorithm for a log we have to be an approximate log struct (subtype of approximate inverse retraction).

We should discuss
* backwards compatibility to the old variant of the log with keywords (currently this is the case), but we could also deprecate this already
* the docs are currently in the Stiefel manifold since (similar to PadeRetraction) that is the only manifold where this occurs. We should move it to base when we have a second manifold that needs this (and at that time also add the analogue for exp).