### PR TITLE
introduce a vector transport for plain types on ProductManifold

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -1073,25 +1073,22 @@ end
 function vector_bundle_transport(::VectorSpaceType, M::ProductManifold)
     return ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds))
 end
-
-function vector_transport_direction!(
-    M::ProductManifold,
-    Y,
-    p,
-    X,
-    d,
-    m::AbstractVectorTransportMethod,
-)
-    return vector_transport_direction!(
-        M,
-        Y,
-        p,
-        X,
-        d,
-        ProductVectorTransport(map(_ -> m, M.manifolds)),
+for T in [ManifoldsBase.VECTOR_TRANSPORT_DISAMBIGUATION..., AbstractVectorTransportMethod]
+    eval(
+        quote
+            function vector_transport_direction!(M::ProductManifold, Y, p, X, d, m::$T)
+                return vector_transport_direction!(
+                    M,
+                    Y,
+                    p,
+                    X,
+                    d,
+                    ProductVectorTransport(map(_ -> m, M.manifolds)),
+                )
+            end
+        end,
     )
 end
-
 function vector_transport_direction!(
     M::ProductManifold,
     Y,
@@ -1122,21 +1119,20 @@ base manifold.
 """
 vector_transport_to(::ProductManifold, ::Any, ::Any, ::Any, ::ProductVectorTransport)
 
-function vector_transport_to!(
-    M::ProductManifold,
-    Y,
-    p,
-    X,
-    q,
-    m::AbstractVectorTransportMethod,
-)
-    return vector_transport_to!(
-        M,
-        Y,
-        p,
-        X,
-        q,
-        ProductVectorTransport(map(_ -> m, M.manifolds)),
+for T in [ManifoldsBase.VECTOR_TRANSPORT_DISAMBIGUATION..., AbstractVectorTransportMethod]
+    eval(
+        quote
+            function vector_transport_to!(M::ProductManifold, Y, p, X, q, m::$T)
+                return vector_transport_to!(
+                    M,
+                    Y,
+                    p,
+                    X,
+                    q,
+                    ProductVectorTransport(map(_ -> m, M.manifolds)),
+                )
+            end
+        end,
     )
 end
 function vector_transport_to!(M::ProductManifold, Y, p, X, q, m::ProductVectorTransport)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -798,7 +798,7 @@ end
 
 Calculate the number of manifolds multiplied in the given [`ProductManifold`](@ref) `M`.
 """
-number_of_components(M::ProductManifold{𝔽,<:NTuple{N,Any}}) where {𝔽,N} = N
+number_of_components(::ProductManifold{𝔽,<:NTuple{N,Any}}) where {𝔽,N} = N
 
 function ProductFVectorDistribution(
     type::VectorBundleFibers{<:VectorSpaceType,<:ProductManifold},
@@ -1016,7 +1016,7 @@ function _show_product_manifold_no_header(io::IO, M)
     return nothing
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", M::ProductManifold)
+function Base.show(io::IO, ::MIME"text/plain", M::ProductManifold)
     n = length(M.manifolds)
     print(io, "ProductManifold with $(n) submanifold$(n == 1 ? "" : "s"):")
     return _show_product_manifold_no_header(io, M)
@@ -1070,29 +1070,46 @@ function Distributions.support(tvd::ProductFVectorDistribution)
     )
 end
 
-function vector_bundle_transport(fiber::VectorSpaceType, M::ProductManifold)
+function vector_bundle_transport(::VectorSpaceType, M::ProductManifold)
     return ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds))
 end
 
-function vector_transport_direction(M::ProductManifold, p, X, d)
-    return vector_transport_direction(
-        M,
-        p,
-        X,
-        d,
-        ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds)),
-    )
-end
-
-function vector_transport_direction!(M::ProductManifold, Y, p, X, d)
+function vector_transport_direction!(
+    M::ProductManifold,
+    Y,
+    p,
+    X,
+    d,
+    m::AbstractVectorTransportMethod,
+)
     return vector_transport_direction!(
         M,
         Y,
         p,
         X,
         d,
-        ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds)),
+        ProductVectorTransport(map(_ -> m, M.manifolds)),
     )
+end
+
+function vector_transport_direction!(
+    M::ProductManifold,
+    Y,
+    p,
+    X,
+    d,
+    m::ProductVectorTransport,
+)
+    map(
+        vector_transport_direction!,
+        M.manifolds,
+        submanifold_components(M, Y),
+        submanifold_components(M, p),
+        submanifold_components(M, X),
+        submanifold_components(M, d),
+        m.methods,
+    )
+    return Y
 end
 
 @doc raw"""
@@ -1104,24 +1121,22 @@ This method is performed elementwise, i.e. the method `m` has to be implemented 
 base manifold.
 """
 vector_transport_to(::ProductManifold, ::Any, ::Any, ::Any, ::ProductVectorTransport)
-function vector_transport_to(M::ProductManifold, p, X, q)
-    return vector_transport_to(
-        M,
-        p,
-        X,
-        q,
-        ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds)),
-    )
-end
 
-function vector_transport_to!(M::ProductManifold, Y, p, X, q)
+function vector_transport_to!(
+    M::ProductManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::AbstractVectorTransportMethod,
+)
     return vector_transport_to!(
         M,
         Y,
         p,
         X,
         q,
-        ProductVectorTransport(map(_ -> ParallelTransport(), M.manifolds)),
+        ProductVectorTransport(map(_ -> m, M.manifolds)),
     )
 end
 function vector_transport_to!(M::ProductManifold, Y, p, X, q, m::ProductVectorTransport)

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -441,6 +441,27 @@ end
         @test isapprox(Mse, q, Y, Z)
     end
 
+    @testset "Implicit product vector transport" begin
+        p = ProductRepr([1.0, 0.0, 0.0], [0.0, 0.0])
+        q = ProductRepr([0.0, 1.0, 0.0], [2.0, 0.0])
+        X = log(Mse, p, q)
+        for m in [ParallelTransport(), SchildsLadderTransport(), PoleLadderTransport()]
+            Y = vector_transport_to(Mse, p, X, q, m)
+            Z1 = vector_transport_to(
+                Mse.manifolds[1],
+                submanifold_component.([p, X, q], Ref(1))...,
+                m,
+            )
+            Z2 = vector_transport_to(
+                Mse.manifolds[2],
+                submanifold_component.([p, X, q], Ref(2))...,
+                m,
+            )
+            Z = ProductRepr(Z1, Z2)
+            @test isapprox(Mse, q, Y, Z)
+        end
+    end
+
     @testset "prod_point" begin
         shape_se = Manifolds.ShapeSpecification(reshapers[1], M1, M2)
         Ts = SizedVector{3,Float64}

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -460,6 +460,21 @@ end
             Z = ProductRepr(Z1, Z2)
             @test isapprox(Mse, q, Y, Z)
         end
+        for m in [ParallelTransport(), SchildsLadderTransport(), PoleLadderTransport()]
+            Y = vector_transport_direction(Mse, p, X, X, m)
+            Z1 = vector_transport_direction(
+                Mse.manifolds[1],
+                submanifold_component.([p, X, X], Ref(1))...,
+                m,
+            )
+            Z2 = vector_transport_direction(
+                Mse.manifolds[2],
+                submanifold_component.([p, X, X], Ref(2))...,
+                m,
+            )
+            Z = ProductRepr(Z1, Z2)
+            @test isapprox(Mse, q, Y, Z)
+        end
     end
 
     @testset "prod_point" begin


### PR DESCRIPTION
This avoids (a) the necessity to overwrite the nonmutatig function and (b) implicitly turns any plain (non-`ProductVectorTransport` type) into a `ProductVectorTransportType` with copies of that type inside.

Partly resolves #384