### PR TITLE
Fixes a bug, that occured when calling `exp!(Rotations(2), p, p, X)` since `q=p` was modified.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -165,7 +165,7 @@ function exp!(M::Rotations{2}, q, p, X)
     @assert size(q) == (2, 2)
     θ = get_coordinates(M, p, X, DefaultOrthogonalBasis())[1]
     sinθ, cosθ = sincos(θ)
-    return copyto!(q, p * [cosθ sinθ; -sinθ cosθ])
+    return copyto!(q, p * SA[cosθ sinθ; -sinθ cosθ])
 end
 function exp!(M::Rotations{3}, q, p, X)
     θ = norm(M, p, X) / sqrt(2)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -165,7 +165,7 @@ function exp!(M::Rotations{2}, q, p, X)
     @assert size(q) == (2, 2)
     θ = get_coordinates(M, p, X, DefaultOrthogonalBasis())[1]
     sinθ, cosθ = sincos(θ)
-    return copyto!(q, p * SA[cosθ sinθ; -sinθ cosθ])
+    return copyto!(q, p * SA[cosθ -sinθ; sinθ cosθ])
 end
 function exp!(M::Rotations{3}, q, p, X)
     θ = norm(M, p, X) / sqrt(2)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -165,13 +165,7 @@ function exp!(M::Rotations{2}, q, p, X)
     @assert size(q) == (2, 2)
     θ = get_coordinates(M, p, X, DefaultOrthogonalBasis())[1]
     sinθ, cosθ = sincos(θ)
-    @inbounds begin
-        q[1] = cosθ
-        q[2] = sinθ
-        q[3] = -sinθ
-        q[4] = cosθ
-    end
-    return copyto!(q, p * q)
+    return copyto!(q, p * [cosθ sinθ; -sinθ cosθ])
 end
 function exp!(M::Rotations{3}, q, p, X)
     θ = norm(M, p, X) / sqrt(2)

--- a/test/rotations.jl
+++ b/test/rotations.jl
@@ -63,7 +63,8 @@ include("utils.jl")
         @test norm(M, pts[1], v) ≈ (angles[2] - angles[1]) * sqrt(2)
 
         # check that exp! does not have a side effect
-        q = copy(M, pts[1])
+        q = allocate(pts[1])
+        copyto!(M, q, pts[1])
         q2 = exp(M, pts[1], v)
         exp!(M, q, q, v)
         @test norm(q - q2) ≈ 0

--- a/test/rotations.jl
+++ b/test/rotations.jl
@@ -62,6 +62,12 @@ include("utils.jl")
         v = log(M, pts[1], pts[2])
         @test norm(M, pts[1], v) ≈ (angles[2] - angles[1]) * sqrt(2)
 
+        # check that exp! does not have a side effect
+        q = deeocopy(pts[1])
+        q2 = exp(M, pts[1], v)
+        exp!(M, q, q, v)
+        @test norm(q - q2) ≈ 0
+
         v14_polar = inverse_retract(M, pts[1], pts[4], Manifolds.PolarInverseRetraction())
         p4_polar = retract(M, pts[1], v14_polar, Manifolds.PolarRetraction())
         @test isapprox(M, pts[4], p4_polar)

--- a/test/rotations.jl
+++ b/test/rotations.jl
@@ -63,7 +63,7 @@ include("utils.jl")
         @test norm(M, pts[1], v) ≈ (angles[2] - angles[1]) * sqrt(2)
 
         # check that exp! does not have a side effect
-        q = deeocopy(pts[1])
+        q = copy(M, pts[1])
         q2 = exp(M, pts[1], v)
         exp!(M, q, q, v)
         @test norm(q - q2) ≈ 0


### PR DESCRIPTION
So the `exp!` returned a wrong result when called as `exp!(M, p, p X)` due to this side effect. Also adds a test for this.