### PR TITLE
Add in-place tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.7"
+version = "0.5.8"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/EssentialManifold.jl
+++ b/src/manifolds/EssentialManifold.jl
@@ -186,10 +186,10 @@ function log!(M::EssentialManifold, X, p, q)
     # compute the closest representative of q
     t = 0
     f_min = Inf
-    q2 = copy(M,q)
+    q2 = copy(M, q)
 
     if !M.is_signed
-        q2min = copy(M,q)
+        q2min = copy(M, q)
         for k in 1:4
             #flip sign in q to get another member of its equivalence class
             if k == 2
@@ -203,7 +203,7 @@ function log!(M::EssentialManifold, X, p, q)
             end
             t_temp, f_temp = dist_min_angle_pair(p, q2)
             if f_temp < f_min
-                q2min = copy(M,q2)
+                q2min = copy(M, q2)
                 f_min = f_temp
                 t = t_temp
             end

--- a/src/manifolds/EssentialManifold.jl
+++ b/src/manifolds/EssentialManifold.jl
@@ -186,10 +186,10 @@ function log!(M::EssentialManifold, X, p, q)
     # compute the closest representative of q
     t = 0
     f_min = Inf
-    q2 = deepcopy(q)
+    q2 = copy(M,q)
 
     if !M.is_signed
-        q2min = deepcopy(q)
+        q2min = copy(M,q)
         for k in 1:4
             #flip sign in q to get another member of its equivalence class
             if k == 2
@@ -203,7 +203,7 @@ function log!(M::EssentialManifold, X, p, q)
             end
             t_temp, f_temp = dist_min_angle_pair(p, q2)
             if f_temp < f_min
-                q2min = deepcopy(q2)
+                q2min = copy(M,q2)
                 f_min = f_temp
                 t = t_temp
             end

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -165,13 +165,7 @@ function exp!(M::Rotations{2}, q, p, X)
     @assert size(q) == (2, 2)
     θ = get_coordinates(M, p, X, DefaultOrthogonalBasis())[1]
     sinθ, cosθ = sincos(θ)
-    @inbounds begin
-        q[1] = cosθ
-        q[2] = sinθ
-        q[3] = -sinθ
-        q[4] = cosθ
-    end
-    return copyto!(q, p * q)
+    return copyto!(q, p * SA[cosθ -sinθ; sinθ cosθ])
 end
 function exp!(M::Rotations{3}, q, p, X)
     θ = norm(M, p, X) / sqrt(2)

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -274,7 +274,14 @@ function exp!(B::VectorBundle, q, p, X)
     VXM, VXF = submanifold_components(B.manifold, X)
     # this temporary avoids overwriting `p` when `q` and `p` occupy the same memory
     xqt = exp(B.manifold, xp, VXM)
-    vector_transport_to!(B.manifold, Xq, xp, Xp + VXF, xqt, B.vector_transport.method_point)
+    vector_transport_direction!(
+        B.manifold,
+        Xq,
+        xp,
+        Xp + VXF,
+        VXM,
+        B.vector_transport.method_point,
+    )
     copyto!(B.manifold, xq, xqt)
     return q
 end

--- a/src/manifolds/VectorBundle.jl
+++ b/src/manifolds/VectorBundle.jl
@@ -272,8 +272,10 @@ function exp!(B::VectorBundle, q, p, X)
     xp, Xp = submanifold_components(B.manifold, p)
     xq, Xq = submanifold_components(B.manifold, q)
     VXM, VXF = submanifold_components(B.manifold, X)
-    exp!(B.manifold, xq, xp, VXM)
-    vector_transport_to!(B.manifold, Xq, xp, Xp + VXF, xq, B.vector_transport.method_point)
+    # this temporary avoids overwriting `p` when `q` and `p` occupy the same memory
+    xqt = exp(B.manifold, xp, VXM)
+    vector_transport_to!(B.manifold, Xq, xp, Xp + VXF, xqt, B.vector_transport.method_point)
+    copyto!(B.manifold, xq, xqt)
     return q
 end
 function exp!(M::TangentSpaceAtPoint, q, p, X)

--- a/src/tests/tests_general.jl
+++ b/src/tests/tests_general.jl
@@ -630,8 +630,8 @@ function test_manifold(
                 p3 = mid_point(M, pts[1], pts[2])
                 mid_point!(M, p1, p1, pts[2])
                 mid_point!(M, p2, pts[1], p2)
-                Test.@test p3 == p1
-                Test.@test p3 == p2
+                Test.@test isapprox(M, p3, p1)
+                Test.@test isapprox(M, p3, p2)
             end
         end
     end

--- a/src/tests/tests_general.jl
+++ b/src/tests/tests_general.jl
@@ -313,7 +313,7 @@ function test_manifold(
                     X2 = deepcopy(X)
                     q = retract(M, p2, X2, retr_method)
                     retract!(M, p2, p2, X, retr_method)
-                    Test.@test p2 == q
+                    Test.@test isapprox(M, p2, q)
                     # This test is not reasonable for `inverse_retract!(M, X, p, q, m)`,
                     # since X is of different type/concept than p,q
                 end
@@ -487,7 +487,7 @@ function test_manifold(
                                 X1a = deepcopy(X1)
                                 Xt = vector_transport_to(M, pts[1], X1, pts32, vtm)
                                 vector_transport_to!(M, X1a, pts[1], X1a, pts32, vtm)
-                                Test.@test X1a == Xt
+                                Test.@test isapprox(M, pts[1], X1a, Xt)
                             end
                     end
                     if test_dir
@@ -501,8 +501,8 @@ function test_manifold(
                                 Xt = vector_transport_direction(M, pts[1], X1, X2, vtm)
                                 vector_transport_direction!(M, X1a, pts[1], X1a, X2, vtm)
                                 vector_transport_direction!(M, X2a, pts[1], X1, X2a, vtm)
-                                Test.@test X1a == Xt
-                                Test.@test X2a == Xt
+                                Test.@test isapprox(M, pts[1], X1a, Xt)
+                                Test.@test isapprox(M, pts[1], X2a, Xt)
                             end
                     end
                 end

--- a/src/tests/tests_general.jl
+++ b/src/tests/tests_general.jl
@@ -278,8 +278,8 @@ function test_manifold(
         Test.@test norm(M, pts[1], X1) ≈ sqrt(inner(M, pts[1], X1, X1))
 
         (test_inplace && is_mutating) && Test.@testset "inplace test for exp!" begin
-            p = deepcopy(pts[1])
-            X = deepcopy(X1)
+            p = copy(M, pts[1])
+            X = copy(M, pts[1], X1)
             q = exp(M, p, X)
             exp!(M, p, p, X)
             Test.@test isapprox(M, p, q)
@@ -309,8 +309,8 @@ function test_manifold(
                 end
                 Test.@test is_point(M, new_pt)
                 (test_inplace && is_mutating) && Test.@testset "inplace test for retract!" begin
-                    p2 = deepcopy(p)
-                    X2 = deepcopy(X)
+                    p2 = copy(M, p)
+                    X2 = copy(M, p, X)
                     q = retract(M, p2, X2, retr_method)
                     retract!(M, p2, p2, X, retr_method)
                     Test.@test isapprox(M, p2, q)
@@ -484,7 +484,7 @@ function test_manifold(
                         Test.@test isapprox(M, pts32, v1t1, v1t1_m)
                         test_inplace &&
                             Test.@testset "inplace test for vector_transport_to!" begin
-                                X1a = deepcopy(X1)
+                                X1a = copy(M, pts[1], X1)
                                 Xt = vector_transport_to(M, pts[1], X1, pts32, vtm)
                                 vector_transport_to!(M, X1a, pts[1], X1a, pts32, vtm)
                                 Test.@test isapprox(M, pts[1], X1a, Xt)
@@ -496,8 +496,8 @@ function test_manifold(
                         Test.@test isapprox(M, pts32, v1t2, v1t2_m)
                         test_inplace &&
                             Test.@testset "inplace test for vector_transport_direction!" begin
-                                X1a = deepcopy(X1)
-                                X2a = deepcopy(X2)
+                                X1a = copy(M, pts[1], X1)
+                                X2a = copy(M, pts[1], X2)
                                 Xt = vector_transport_direction(M, pts[1], X1, X2, vtm)
                                 vector_transport_direction!(M, X1a, pts[1], X1a, X2, vtm)
                                 vector_transport_direction!(M, X2a, pts[1], X1, X2a, vtm)
@@ -625,8 +625,8 @@ function test_manifold(
             mid_point!(M, mpm, pts[1], pts[2])
             Test.@test isapprox(M, mpm, mid_point12; atol=atolp1p2, rtol=rtolp1p2)
             test_inplace && Test.@testset "inplace test for midpoint!" begin
-                p1 = deepcopy(pts[1])
-                p2 = deepcopy(pts[2])
+                p1 = copy(M, pts[1])
+                p2 = copy(M, pts[2])
                 p3 = mid_point(M, pts[1], pts[2])
                 mid_point!(M, p1, p1, pts[2])
                 mid_point!(M, p2, pts[1], p2)

--- a/src/tests/tests_general.jl
+++ b/src/tests/tests_general.jl
@@ -282,7 +282,7 @@ function test_manifold(
             X = deepcopy(X1)
             q = exp(M, p, X)
             exp!(M, p, p, X)
-            Test.@test p == q
+            Test.@test isapprox(M, p, q)
             # This test is not reasonable for `log!(M, X, p, q)`,
             # since X is of different type/concept than p,q
         end

--- a/test/centered_matrices.jl
+++ b/test/centered_matrices.jl
@@ -58,6 +58,7 @@ include("utils.jl")
             test_default_vector_transport=true,
             is_tangent_atol_multiplier=1,
             is_point_atol_multiplier=1,
+            test_inplace=true,
         )
     end
 end

--- a/test/cholesky_space.jl
+++ b/test/cholesky_space.jl
@@ -32,6 +32,7 @@ include("utils.jl")
             test_reverse_diff=false,
             test_vee_hat=false,
             exp_log_atol_multiplier=8.0,
+            test_inplace=true,
         )
     end
     @testset "Test Error cases in is_point and is_vector" begin

--- a/test/elliptope.jl
+++ b/test/elliptope.jl
@@ -47,6 +47,7 @@ include("utils.jl")
                 default_inverse_retraction_method=nothing,
                 default_retraction_method=ProjectionRetraction(),
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
         end
     end

--- a/test/essential_manifold.jl
+++ b/test/essential_manifold.jl
@@ -54,6 +54,7 @@ include("utils.jl")
             test_exp_log=true,
             mid_point12=nothing,
             exp_log_atol_multiplier=4,
+            test_inplace=true,
         )
     end
     @testset "Unsigned Essential" begin

--- a/test/euclidean.jl
+++ b/test/euclidean.jl
@@ -105,6 +105,7 @@ using Manifolds: induced_basis
                     basis_types_to_from=basis_types,
                     basis_has_specialized_diagonalizing_get=true,
                     test_vee_hat=isa(M, Euclidean),
+                    test_inplace=true,
                 )
             end
         end

--- a/test/fixed_rank.jl
+++ b/test/fixed_rank.jl
@@ -188,6 +188,7 @@ include("utils.jl")
                 projection_atol_multiplier=15,
                 retraction_methods=[PolarRetraction()],
                 mid_point12=nothing,
+                test_inplace=true,
             )
         end
     end

--- a/test/generalized_grassmann.jl
+++ b/test/generalized_grassmann.jl
@@ -86,6 +86,7 @@ include("utils.jl")
                 is_tangent_atol_multiplier=4 * 10.0^2,
                 retraction_methods=[PolarRetraction(), ProjectionRetraction()],
                 mid_point12=nothing,
+                test_inplace=true,
             )
         end
     end

--- a/test/generalized_stiefel.jl
+++ b/test/generalized_stiefel.jl
@@ -83,6 +83,7 @@ include("utils.jl")
                 exp_log_atol_multiplier=10.0^3 * (VERSION >= v"1.6-DEV" ? 10.0^8 : 1.0),
                 retraction_methods=[PolarRetraction(), ProjectionRetraction()],
                 mid_point12=nothing,
+                test_inplace=true,
             )
         end
     end

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -52,6 +52,7 @@ include("utils.jl")
             [x[1:2], y[1:2], z[1:2]];
             test_representation_size=false,
             test_reverse_diff=false, #VERSION > v"1.2",
+            test_inplace=true,
         )
         @test sprint(show, "text/plain", NE) == """
         GraphManifold

--- a/test/grassmann.jl
+++ b/test/grassmann.jl
@@ -171,6 +171,7 @@ include("utils.jl")
                 ],
                 exp_log_atol_multiplier=10.0^3,
                 is_tangent_atol_multiplier=20.0,
+                test_inplace=true,
             )
 
             @testset "inner/norm" begin

--- a/test/hyperbolic.jl
+++ b/test/hyperbolic.jl
@@ -169,6 +169,7 @@ include("utils.jl")
                 test_reverse_diff=is_plain_array,
                 test_tangent_vector_broadcasting=is_plain_array,
                 test_vector_spaces=is_plain_array,
+                test_inplace=true,
             )
         end
     end

--- a/test/multinomial_doubly_stochastic.jl
+++ b/test/multinomial_doubly_stochastic.jl
@@ -60,6 +60,7 @@ include("utils.jl")
                 default_retraction_method=ProjectionRetraction(),
                 is_tangent_atol_multiplier=20,
                 is_point_atol_multiplier=20,
+                test_inplace=true,
             )
         end
     end

--- a/test/multinomial_matrices.jl
+++ b/test/multinomial_matrices.jl
@@ -42,6 +42,7 @@ include("utils.jl")
             test_musical_isomorphisms=true,
             test_default_vector_transport=false,
             is_tangent_atol_multiplier=5.0,
+            test_inplace=true,
         )
     end
 end

--- a/test/multinomial_symmetric.jl
+++ b/test/multinomial_symmetric.jl
@@ -65,6 +65,7 @@ include("utils.jl")
                 default_retraction_method=ProjectionRetraction(),
                 is_tangent_atol_multiplier=20,
                 is_point_atol_multiplier=20,
+                test_inplace=true,
             )
         end
     end

--- a/test/oblique.jl
+++ b/test/oblique.jl
@@ -44,6 +44,7 @@ include("utils.jl")
             vector_transport_methods=transports,
             basis_types_to_from=basis_types,
             exp_log_atol_multiplier=1,
+            test_inplace=true,
         )
     end
 end

--- a/test/power_manifold.jl
+++ b/test/power_manifold.jl
@@ -209,6 +209,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12.0,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=2 * prod(power_dimensions(Ms1)),
+                test_inplace=true,
             )
         end
     end
@@ -230,6 +231,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=2 * prod(power_dimensions(Ms2)),
+                test_inplace=true,
             )
         end
     end
@@ -253,6 +255,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=2e2 * prod(power_dimensions(Mr2)),
+                test_inplace=true,
             )
         end
     end
@@ -276,6 +279,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=4e2 * prod(power_dimensions(Mrn1)),
+                test_inplace=true,
             )
         end
     end
@@ -297,6 +301,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=4e3 * prod(power_dimensions(Mr2)),
+                test_inplace=true,
             )
         end
     end
@@ -318,6 +323,7 @@ Random.seed!(42)
                 retraction_atol_multiplier=12,
                 is_tangent_atol_multiplier=12.0,
                 exp_log_atol_multiplier=4e3 * prod(power_dimensions(Mrn2)),
+                test_inplace=true,
             )
         end
     end
@@ -340,6 +346,7 @@ Random.seed!(42)
             retraction_atol_multiplier=12,
             is_tangent_atol_multiplier=12.0,
             exp_log_atol_multiplier=1.0,
+            test_inplace=true,
         )
     end
 
@@ -379,6 +386,7 @@ Random.seed!(42)
             rand_tvector_atol_multiplier=5.0,
             retraction_atol_multiplier=12,
             is_tangent_atol_multiplier=12.0,
+            test_inplace=true,
         )
     end
 

--- a/test/probability_simplex.jl
+++ b/test/probability_simplex.jl
@@ -59,6 +59,7 @@ include("utils.jl")
                 is_tangent_atol_multiplier=5.0,
                 inverse_retraction_methods=[SoftmaxInverseRetraction()],
                 retraction_methods=[SoftmaxRetraction()],
+                test_inplace=true,
             )
         end
     end

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -373,6 +373,7 @@ end
                 ],
                 is_tangent_atol_multiplier=1,
                 exp_log_atol_multiplier=1,
+                test_inplace=true,
             )
         end
     end
@@ -429,6 +430,7 @@ end
         test_reverse_diff=false,
         is_tangent_atol_multiplier=1,
         exp_log_atol_multiplier=1,
+        test_inplace=true,
     )
 
     @testset "product vector transport" begin

--- a/test/projective_space.jl
+++ b/test/projective_space.jl
@@ -67,6 +67,7 @@ include("utils.jl")
                     QRInverseRetraction(),
                 ],
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
         end
 

--- a/test/rotations.jl
+++ b/test/rotations.jl
@@ -51,6 +51,7 @@ include("utils.jl")
             point_distributions=[Manifolds.normal_rotation_distribution(M, pts[1], 1.0)],
             tvector_distributions=[Manifolds.normal_tvector_distribution(M, pts[1], 1.0)],
             basis_types_to_from=basis_types,
+            test_inplace=true,
         )
 
         @testset "log edge cases" begin
@@ -115,6 +116,7 @@ include("utils.jl")
                 basis_types_to_from=basis_types,
                 exp_log_atol_multiplier=20,
                 retraction_atol_multiplier=12,
+                test_inplace=true,
             )
 
             @testset "vee/hat" begin

--- a/test/rotations.jl
+++ b/test/rotations.jl
@@ -62,6 +62,13 @@ include("utils.jl")
         v = log(M, pts[1], pts[2])
         @test norm(M, pts[1], v) ≈ (angles[2] - angles[1]) * sqrt(2)
 
+        # check that exp! does not have a side effect
+        q = allocate(pts[1])
+        copyto!(M, q, pts[1])
+        q2 = exp(M, pts[1], v)
+        exp!(M, q, q, v)
+        @test norm(q - q2) ≈ 0
+
         v14_polar = inverse_retract(M, pts[1], pts[4], Manifolds.PolarInverseRetraction())
         p4_polar = retract(M, pts[1], v14_polar, Manifolds.PolarRetraction())
         @test isapprox(M, pts[4], p4_polar)

--- a/test/skewhermitian.jl
+++ b/test/skewhermitian.jl
@@ -73,6 +73,7 @@ end
                 ),
                 basis_types_to_from=bases,
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
         end
     end
@@ -94,6 +95,7 @@ end
                 basis_types_vecs=(DefaultOrthonormalBasis(ℂ),),
                 basis_types_to_from=(DefaultOrthonormalBasis(ℂ),),
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
             @test isapprox(
                 -pts_complex[1],

--- a/test/spectrahedron.jl
+++ b/test/spectrahedron.jl
@@ -51,6 +51,7 @@ include("utils.jl")
                 vector_transport_methods=[ProjectionTransport()],
                 default_inverse_retraction_method=nothing,
                 default_retraction_method=ProjectionRetraction(),
+                test_inplace=true,
             )
         end
     end

--- a/test/sphere.jl
+++ b/test/sphere.jl
@@ -58,6 +58,7 @@ using ManifoldsBase: TFVector
                 inverse_retraction_methods=[ProjectionInverseRetraction()],
                 is_tangent_atol_multiplier=1,
                 test_atlases=test_atlases,
+                test_inplace=true,
             )
             @test isapprox(-pts[1], exp(M, pts[1], log(M, pts[1], -pts[1])))
         end

--- a/test/sphere_symmetric_matrices.jl
+++ b/test/sphere_symmetric_matrices.jl
@@ -48,6 +48,7 @@ include("utils.jl")
             test_musical_isomorphisms=true,
             test_default_vector_transport=true,
             is_tangent_atol_multiplier=2,
+            test_inplace=true,
         )
     end
     @testset "Complex Sphere Symmetric Matrices Basics" begin
@@ -73,6 +74,7 @@ include("utils.jl")
             is_point_atol_multiplier=2,
             projection_atol_multiplier=2,
             exp_log_atol_multiplier=2,
+            test_inplace=true,
         )
     end
 end

--- a/test/stiefel.jl
+++ b/test/stiefel.jl
@@ -152,6 +152,7 @@ using Manifolds: default_metric_dispatch
                 ],
                 test_vector_transport_direction=[true, true, false],
                 mid_point12=nothing,
+                test_inplace=true,
             )
 
             @testset "inner/norm" begin
@@ -238,6 +239,7 @@ using Manifolds: default_metric_dispatch
                 ],
                 test_vector_transport_direction=[true, true, false],
                 mid_point12=nothing,
+                test_inplace=true,
             )
 
             @testset "inner/norm" begin

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -58,6 +58,7 @@ include("utils.jl")
                 ),
                 basis_types_to_from=bases,
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
             test_manifold(
                 M_complex,
@@ -75,6 +76,7 @@ include("utils.jl")
                 basis_types_vecs=(DefaultOrthonormalBasis(ℂ),),
                 basis_types_to_from=(DefaultOrthonormalBasis(ℂ),),
                 is_tangent_atol_multiplier=1,
+                test_inplace=true,
             )
             @test isapprox(-pts[1], exp(M, pts[1], log(M, pts[1], -pts[1])))
         end # testset type $T

--- a/test/symmetric_positive_definite.jl
+++ b/test/symmetric_positive_definite.jl
@@ -69,6 +69,7 @@ using Manifolds: default_metric_dispatch
                     basis_types_vecs=basis_types,
                     basis_types_to_from=basis_types,
                     is_tangent_atol_multiplier=1,
+                    test_inplace=true,
                 )
             end
             @testset "Test Error cases in is_point and is_vector" begin

--- a/test/symmetric_positive_semidefinite_fixed_rank.jl
+++ b/test/symmetric_positive_semidefinite_fixed_rank.jl
@@ -32,6 +32,7 @@ include("utils.jl")
                     test_forward_diff=false,
                     test_reverse_diff=false,
                     test_project_tangent=true,
+                    test_inplace=true,
                 )
             end
         end

--- a/test/torus.jl
+++ b/test/torus.jl
@@ -34,6 +34,7 @@ include("utils.jl")
             test_default_vector_transport=false,
             basis_types_to_from=basis_types,
             is_tangent_atol_multiplier=1,
+            test_inplace=true,
         )
     end
 end

--- a/test/vector_bundle.jl
+++ b/test/vector_bundle.jl
@@ -68,6 +68,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 vector_transport_methods=[ParallelTransport()],
                 basis_types_vecs=basis_types,
                 projection_atol_multiplier=4,
+                test_inplace=true,
             )
 
             # tangent space at point
@@ -93,6 +94,7 @@ struct TestVectorSpaceType <: VectorSpaceType end
                 test_default_vector_transport=true,
                 basis_types_vecs=basis_types,
                 projection_atol_multiplier=4,
+                test_inplace=true,
             )
         end
     end


### PR DESCRIPTION
This PR adds tests for inlace checks for the following mutating variants

* [x] exp!
* [x] vector transports (not for `_along` since we do not have proper tests)
* [x] retractions
* [x] mid point  

For `log!`, `inverse_retract!`, `embed!`, `project!` such tests do not seem too useful, since often the dimension / return type (vector instead of point) changes, so then in-place is anyways not recommended in the generic interface. Am I missing any others where a mutating return might be given as input?

## Todo

* [x] Which manifolds to activate?
* [x] Wait for #388 to be finished 
* [x] Wait for `copy` from JuliaManifolds/ManifoldsBase.jl#77 to be available to replace `deepcopy`s

This resolves #393.