### PR TITLE
Tightens tests for points/vectors on product manifolds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.5.12"
+version = "0.5.13"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -141,11 +141,11 @@ function affine_matrix(::GT, ::Identity{GT}) where {n,GT<:SpecialEuclidean{n}}
     return Diagonal{Float64}(I, n)
 end
 
-function check_point(G::SpecialEuclidean{n}, p::AbstractMatrix) where {n}
+function check_point(G::SpecialEuclidean{n}, p::AbstractMatrix; kwargs...) where {n}
     err1 = check_point(Euclidean(n + 1, n + 1), p)
     !isnothing(err1) && return err1
-    err2a = check_point(submanifold(G, 1), p[1:n, end])
-    err2b = check_point(submanifold(G, 2), p[1:n, 1:n])
+    err2a = check_point(submanifold(G, 1), p[1:n, end]; kwargs...)
+    err2b = check_point(submanifold(G, 2), p[1:n, 1:n]; kwargs...)
     isnothing(err2a) && return err2b
     isnothing(err2b) && return err2a
     return CompositeManifoldError([err2a, err2b])
@@ -153,12 +153,13 @@ end
 function check_vector(
     G::SpecialEuclidean{n},
     p::AbstractMatrix,
-    X::AbstractMatrix,
+    X::AbstractMatrix;
+    kwargs...,
 ) where {n}
     err1 = check_point(Euclidean(n + 1, n + 1), X)
     !isnothing(err1) && return err1
-    err2a = check_vector(submanifold(G, 1), p[1:n, end], X[1:n, end])
-    err2b = check_vector(submanifold(G, 2), p[1:n, 1:n], X[1:n, 1:n])
+    err2a = check_vector(submanifold(G, 1), p[1:n, end], X[1:n, end]; kwargs...)
+    err2b = check_vector(submanifold(G, 2), p[1:n, 1:n], X[1:n, 1:n]; kwargs...)
     isnothing(err2a) && return err2b
     isnothing(err2b) && return err2a
     return CompositeManifoldError([err2a, err2b])

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -147,7 +147,7 @@ function check_point(G::SpecialEuclidean{n}, p::AbstractMatrix; kwargs...) where
     err1 = check_point(Euclidean(n + 1, n + 1), p)
     !isnothing(err1) && push!(errs, err1)
     # homogeneous
-    if !isapprox(p[end, :], [zeros(n)..., 1]; kwargs...)
+    if !isapprox(p[end, :], [zeros(size(p, 2) - 1)..., 1]; kwargs...)
         push!(
             errs,
             DomainError(
@@ -175,15 +175,15 @@ function check_vector(
 ) where {n}
     errs = DomainError[]
     # Valid matrix
-    err1 = check_point(Euclidean(n + 1, n + 1), p)
+    err1 = check_point(Euclidean(n + 1, n + 1), X)
     !isnothing(err1) && push!(errs, err1)
     # homogeneous
-    if !isapprox(X[end, :], zeros(n + 1); kwargs...)
+    if !isapprox(X[end, :], zeros(size(X, 2)); kwargs...)
         push!(
             errs,
             DomainError(
                 X[end, :],
-                "The last row of $X is not homogeneous, i.e. of form [0,..,0,1].",
+                "The last row of $X is not homogeneous, i.e. of form [0,..,0,0].",
             ),
         )
     end

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -141,6 +141,29 @@ function affine_matrix(::GT, ::Identity{GT}) where {n,GT<:SpecialEuclidean{n}}
     return Diagonal{Float64}(I, n)
 end
 
+function check_point(G::SpecialEuclidean{n}, p::AbstractMatrix) where {n}
+    err1 = check_point(Euclidean(n + 1, n + 1), p)
+    !isnothing(err1) && return err1
+    err2a = check_point(submanifold(G, 1), p[1:n, end])
+    err2b = check_point(submanifold(G, 2), p[1:n, 1:n])
+    isnothing(err2a) && return err2b
+    isnothing(err2b) && return err2a
+    return CompositeManifoldError([err2a, err2b])
+end
+function check_vector(
+    G::SpecialEuclidean{n},
+    p::AbstractMatrix,
+    X::AbstractMatrix,
+) where {n}
+    err1 = check_point(Euclidean(n + 1, n + 1), X)
+    !isnothing(err1) && return err1
+    err2a = check_vector(submanifold(G, 1), p[1:n, end], X[1:n, end])
+    err2b = check_vector(submanifold(G, 2), p[1:n, 1:n], X[1:n, 1:n])
+    isnothing(err2a) && return err2b
+    isnothing(err2b) && return err2a
+    return CompositeManifoldError([err2a, err2b])
+end
+
 @doc raw"""
     screw_matrix(G::SpecialEuclidean, X) -> AbstractMatrix
 
@@ -169,10 +192,10 @@ function screw_matrix(G::SpecialEuclidean{n}, X) where {n}
 end
 screw_matrix(::SpecialEuclidean{n}, X::AbstractMatrix) where {n} = X
 
-function allocate_result(G::SpecialEuclidean{n}, f::typeof(affine_matrix), p...) where {n}
+function allocate_result(::SpecialEuclidean{n}, ::typeof(affine_matrix), p...) where {n}
     return allocate(p[1], Size(n + 1, n + 1))
 end
-function allocate_result(G::SpecialEuclidean{n}, f::typeof(screw_matrix), X...) where {n}
+function allocate_result(::SpecialEuclidean{n}, ::typeof(screw_matrix), X...) where {n}
     return allocate(X[1], Size(n + 1, n + 1))
 end
 

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -156,7 +156,7 @@ end
 function check_point(M::ProductManifold, p; kwargs...)
     return DomainError(
         typeof(p),
-        "The point $p is not a point on $M, since currently only ProductRepr and ProductArray are suppored typoes for points on product manifolds",
+        "The point $p is not a point on $M, since currently only ProductRepr and ProductArray are supported types for points on product manifolds",
     )
 end
 
@@ -192,7 +192,7 @@ end
 function check_vector(M::ProductManifold, p, X; kwargs...)
     return DomainError(
         typeof(X),
-        "The vector $X is not a tangent vector to any tangent space on $M, since currently only ProductRepr and ProductArray are suppored typoes for tangent vectors on product manifolds",
+        "The vector $X is not a tangent vector to any tangent space on $M, since currently only ProductRepr and ProductArray are supported types for tangent vectors on product manifolds",
     )
 end
 

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -153,6 +153,12 @@ function check_point(M::ProductManifold, p::Union{ProductRepr,ProductArray}; kwa
     (length(errors) == 1) && return cerr[1]
     return nothing
 end
+function check_point(M::ProductManifold, p; kwargs...)
+    return DomainError(
+        typeof(p),
+        "The point $p is not a point on $M, since currently only ProductRepr and ProductArray are suppored typoes for points on product manifolds",
+    )
+end
 
 """
     check_vector(M::ProductManifold, p, X; kwargs... )
@@ -182,6 +188,12 @@ function check_vector(
     (length(errors) > 1) && return CompositeManifoldError(cerr)
     (length(errors) == 1) && return cerr[1]
     return nothing
+end
+function check_vector(M::ProductManifold, p, X; kwargs...)
+    return DomainError(
+        typeof(X),
+        "The vector $X is not a tangent vector to any tangent space on $M, since currently only ProductRepr and ProductArray are suppored typoes for tangent vectors on product manifolds",
+    )
 end
 
 function copyto!(M::ProductManifold, q::ProductRepr, p::ProductRepr)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -156,7 +156,7 @@ end
 function check_point(M::ProductManifold, p; kwargs...)
     return DomainError(
         typeof(p),
-        "The point $p is not a point on $M, since currently only ProductRepr and ProductArray are supported types for points on product manifolds",
+        "The point $p is not a point on $M, since currently only ProductRepr and ProductArray are supported types for points on arbitrary product manifolds",
     )
 end
 
@@ -192,7 +192,7 @@ end
 function check_vector(M::ProductManifold, p, X; kwargs...)
     return DomainError(
         typeof(X),
-        "The vector $X is not a tangent vector to any tangent space on $M, since currently only ProductRepr and ProductArray are supported types for tangent vectors on product manifolds",
+        "The vector $X is not a tangent vector to any tangent space on $M, since currently only ProductRepr and ProductArray are supported types for tangent vectors on arbitrary product manifolds",
     )
 end
 

--- a/src/tests/tests_group.jl
+++ b/src/tests/tests_group.jl
@@ -313,7 +313,7 @@ function test_group(
                 for X in Xe_pts
                     g = allocate(g_pts[1])
                     Test.@test group_exp!(G, g, X) === g
-                    Test.@test is_point(G, g; atol=atol)
+                    Test.@test is_point(G, g,true; atol=atol)
                     Test.@test isapprox(G, g, group_exp(G, X); atol=atol)
                     X2 = allocate(X)
                     Test.@test group_log!(G, X2, g) === X2
@@ -350,7 +350,7 @@ function test_group(
                     X_pts[1],
                     Manifolds.GroupExponentialRetraction(conv...),
                 )
-                Test.@test is_point(G, y; atol=atol)
+                Test.@test is_point(G, y, true; atol=atol)
                 X2 = inverse_retract(
                     G,
                     g_pts[1],
@@ -370,7 +370,7 @@ function test_group(
                         X_pts[1],
                         Manifolds.GroupExponentialRetraction(conv...),
                     ) === y
-                    Test.@test is_point(G, y; atol=atol)
+                    Test.@test is_point(G, y, true; atol=atol)
                     X2 = allocate(X_pts[1])
                     Test.@test inverse_retract!(
                         G,

--- a/src/tests/tests_group.jl
+++ b/src/tests/tests_group.jl
@@ -313,7 +313,7 @@ function test_group(
                 for X in Xe_pts
                     g = allocate(g_pts[1])
                     Test.@test group_exp!(G, g, X) === g
-                    Test.@test is_point(G, g,true; atol=atol)
+                    Test.@test is_point(G, g, true; atol=atol)
                     Test.@test isapprox(G, g, group_exp(G, X); atol=atol)
                     X2 = allocate(X)
                     Test.@test group_log!(G, X2, g) === X2

--- a/test/groups/special_euclidean.jl
+++ b/test/groups/special_euclidean.jl
@@ -132,8 +132,20 @@ using ManifoldsBase: VeeOrthogonalBasis
             X = copy(G, p, X_pts[1])
             X[n + 1, n + 1] = 0.1
             @test_throws DomainError is_vector(G, p, X, true)
+            X2 = zeros(n + 2, n + 2)
+            # nearly correct just too large (and the error from before)
+            X2[1:n, 1:n] .= X[1:n, 1:n]
+            X2[1:n, end] .= X[1:n, end]
+            X2[end, end] = X[end, end]
+            @test_throws CompositeManifoldError is_vector(G, p, X2, true)
             p[n + 1, n + 1] = 0.1
             @test_throws DomainError is_point(G, p, true)
+            p2 = zeros(n + 2, n + 2)
+            # nearly correct just too large (and the error from before)
+            p2[1:n, 1:n] .= p[1:n, 1:n]
+            p2[1:n, end] .= p[1:n, end]
+            p2[end, end] = p[end, end]
+            @test_throws CompositeManifoldError is_point(G, p2, true)
         end
 
         @testset "hat/vee" begin

--- a/test/groups/special_euclidean.jl
+++ b/test/groups/special_euclidean.jl
@@ -127,6 +127,13 @@ using ManifoldsBase: VeeOrthogonalBasis
                 test_lie_bracket=true,
                 diff_convs=[(), (LeftAction(),), (RightAction(),)],
             )
+            # specific affine tests
+            p = copy(G, pts[1])
+            X = copy(G, p, X_pts[1])
+            X[n + 1, n + 1] = 0.1
+            @test_throws DomainError is_vector(G, p, X, true)
+            p[n + 1, n + 1] = 0.1
+            @test_throws DomainError is_point(G, p, true)
         end
 
         @testset "hat/vee" begin

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -42,7 +42,7 @@ end
     @test Manifolds.number_of_components(Mse) == 2
     # test that arrays are not points
     @test_throws DomainError is_point(Mse, [1, 2], true)
-    @test_throws DomainError is_vector(Mse, 1, [1, 2]; check_base_point=false, true)
+    @test_throws DomainError is_vector(Mse, 1, [1, 2], true; check_base_point=false)
     types = [Vector{Float64}]
     TEST_FLOAT32 && push!(types, Vector{Float32})
     TEST_STATIC_SIZED && push!(types, MVector{5,Float64})

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -40,6 +40,9 @@ end
         zeros(2, 3),
     )
     @test Manifolds.number_of_components(Mse) == 2
+    # test that arrays are not points
+    @test_throws DomainError is_point(Mse, [1, 2], true)
+    @test_throws DomainError is_vector(Mse, 1, [1, 2], true)
     types = [Vector{Float64}]
     TEST_FLOAT32 && push!(types, Vector{Float32})
     TEST_STATIC_SIZED && push!(types, MVector{5,Float64})

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -42,7 +42,7 @@ end
     @test Manifolds.number_of_components(Mse) == 2
     # test that arrays are not points
     @test_throws DomainError is_point(Mse, [1, 2], true)
-    @test_throws DomainError is_vector(Mse, 1, [1, 2], true)
+    @test_throws DomainError is_vector(Mse, 1, [1, 2]; check_base_point=false, true)
     types = [Vector{Float64}]
     TEST_FLOAT32 && push!(types, Vector{Float32})
     TEST_STATIC_SIZED && push!(types, MVector{5,Float64})


### PR DESCRIPTION
This resolves #349 – by throwing an error when one enters product manifolds with wrong encapsulating types (i.e. neither ProductRepr nor ProductArray). We can loosen this once we also allow tuples or arrays in there (would require rewriting accessing the components).