### PR TITLE
Make `allocate_result(G::SemidirectProductGroup, ::typeof(identity_element))` return `ProductRepr` instead of `ProductArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -57,8 +57,7 @@ function allocate_result(G::SemidirectProductGroup, ::typeof(identity_element))
     N, H = M.manifolds
     np = allocate_result(N, identity_element)
     hp = allocate_result(H, identity_element)
-    reshaper = ShapeSpecification(StaticReshaper(), M.manifolds...)
-    return prod_point(reshaper, np, hp)
+    return ProductRepr(np, hp)
 end
 
 function identity_element!(G::SemidirectProductGroup, q)

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -60,6 +60,14 @@ function allocate_result(G::SemidirectProductGroup, ::typeof(identity_element))
     return ProductRepr(np, hp)
 end
 
+"""
+    identity_element(G::SemidirectProductGroup)
+
+Get the identity element of [`SemidirectProductGroup`](@ref) `G`. Uses [`ProductRepr`](@ref)
+to represent the point.
+"""
+identity_element(G::SemidirectProductGroup)
+
 function identity_element!(G::SemidirectProductGroup, q)
     M = base_manifold(G)
     N, H = M.manifolds


### PR DESCRIPTION
Problem reported in #408 . `ProductArray` is deprecated so it shouldn't be returned by default.