### PR TITLE
`ArrayPartition` as a product manifold representation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -16,6 +16,7 @@ ManifoldsBase = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SimpleWeightedGraphs = "47aef6b3-ad0c-573a-a1e2-d07658019622"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -153,6 +153,7 @@ using StaticArrays
 using Statistics
 using StatsBase
 using StatsBase: AbstractWeights
+using RecursiveArrayTools: ArrayPartition
 
 include("utils.jl")
 

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -177,7 +177,7 @@ end
 # and applies proper padding to the result if `X` happens to be a matrix.
 # Otherwise rare random bugs happen where the padding is not applied.
 function get_vector(G::SemidirectProductGroup, p, X, B::VeeOrthogonalBasis)
-    Y = allocate_result(M, get_vector, p, X)
+    Y = allocate_result(G, get_vector, p, X)
     return get_vector!(G, Y, p, X, B)
 end
 

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -173,6 +173,14 @@ function translate_diff!(G::SemidirectProductGroup, Y, p, q, X, conX::LeftAction
     return Y
 end
 
+# We need to prevent decorator unwrapping so that the correct `get_vector!` gets called
+# and applies proper padding to the result if `X` happens to be a matrix.
+# Otherwise rare random bugs happen where the padding is not applied.
+function get_vector(G::SemidirectProductGroup, p, X, B::VeeOrthogonalBasis)
+    Y = allocate_result(M, get_vector, p, X)
+    return get_vector!(G, Y, p, X, B)
+end
+
 function get_vector!(G::SemidirectProductGroup, Y, p, X, B::VeeOrthogonalBasis)
     M = base_manifold(G)
     N, H = M.manifolds

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -76,7 +76,7 @@ function submanifold_components(
 end
 
 Base.@propagate_inbounds function _padpoint!(
-    ::SpecialEuclidean{n},
+    ::Union{SpecialEuclidean{n},SpecialEuclideanManifold{n}},
     q::AbstractMatrix,
 ) where {n}
     for i in 1:n
@@ -87,7 +87,7 @@ Base.@propagate_inbounds function _padpoint!(
 end
 
 Base.@propagate_inbounds function _padvector!(
-    ::SpecialEuclidean{n},
+    ::Union{SpecialEuclidean{n},SpecialEuclideanManifold{n}},
     X::AbstractMatrix,
 ) where {n}
     for i in 1:(n + 1)

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -1058,7 +1058,7 @@ set the element `[i...]` of a point `q` on a [`ProductManifold`](@ref) by linear
 See also [Array Indexing](https://docs.julialang.org/en/v1/manual/arrays/#man-array-indexing-1) in Julia.
 """
 Base.@propagate_inbounds function Base.setindex!(
-    q::Union{ProductArray,ProductRepr},
+    q::Union{ProductArray,ProductRepr,ArrayPartition},
     p,
     M::ProductManifold,
     i::Union{Integer,Colon,AbstractVector,Val},

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -187,10 +187,11 @@ function get_basis(M::Sphere{n,ℝ}, p, B::DiagonalizingOrthonormalBasis{ℝ}) w
     κ = ones(n)
     if !iszero(B.frame_direction)
         # if we have a nonzero direction for the geodesic, add it and it gets curvature zero from the tensor
-        V = cat(B.frame_direction / norm(M, p, B.frame_direction), V; dims=2)
+        V = hcat(B.frame_direction / norm(M, p, B.frame_direction), V)
         κ[1] = 0 # no curvature along the geodesic direction, if x!=y
     end
-    Ξ = [V[:, i] for i in 1:n]
+    T = typeof(B.frame_direction)
+    Ξ = [convert(T, V[:, i]) for i in 1:n]
     return CachedBasis(B, κ, Ξ)
 end
 

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -190,7 +190,7 @@ function get_basis(M::Sphere{n,ℝ}, p, B::DiagonalizingOrthonormalBasis{ℝ}) w
         V = hcat(B.frame_direction / norm(M, p, B.frame_direction), V)
         κ[1] = 0 # no curvature along the geodesic direction, if x!=y
     end
-    T = typeof(B.frame_direction)
+    T = typeof(similar(B.frame_direction))
     Ξ = [convert(T, V[:, i]) for i in 1:n]
     return CachedBasis(B, κ, Ξ)
 end

--- a/src/product_representations.jl
+++ b/src/product_representations.jl
@@ -237,6 +237,7 @@ submanifold_component(::Any...)
 end
 @inline submanifold_component(M::AbstractManifold, p, i::Val) = submanifold_component(p, i)
 @inline submanifold_component(p, ::Val{I}) where {I} = p.parts[I]
+@inline submanifold_component(p::ArrayPartition, ::Val{I}) where {I} = p.x[I]
 @inline submanifold_component(p, i::Integer) = submanifold_component(p, Val(i))
 
 @doc raw"""
@@ -248,6 +249,7 @@ Get the projected components of `p` on the submanifolds of `M`. The components a
 submanifold_components(::Any...)
 @inline submanifold_components(M::AbstractManifold, p) = submanifold_components(p)
 @inline submanifold_components(p) = p.parts
+@inline submanifold_components(p::ArrayPartition) = p.x
 
 function Base.BroadcastStyle(
     ::Type{<:ProductArray{ShapeSpec}},
@@ -474,3 +476,7 @@ Base.axes(v::ProductRepr) = axes(v.parts)
     end
     return dest
 end
+
+## ArrayPartition
+
+ManifoldsBase._get_vector_cache_broadcast(::ArrayPartition) = Val(false)

--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -4,12 +4,12 @@
         # Interims solution until we follow what was proposed in
         # https://discourse.julialang.org/t/avoid-ambiguities-with-individual-number-element-identity/62465/2
         fmbs = filter(x -> !any(has_type_in_signature.(x, Identity)), mbs)
-        @test length(fmbs) <= 16
+        @test length(fmbs) <= 20
         ms = Test.detect_ambiguities(Manifolds)
         # Interims solution until we follow what was proposed in
         # https://discourse.julialang.org/t/avoid-ambiguities-with-individual-number-element-identity/62465/2
         fms = filter(x -> !any(has_type_in_signature.(x, Identity)), ms)
-        @test length(fms) <= 16
+        @test length(fms) <= 17
         # this test takes way too long to perform regularly
         # @test length(our_base_ambiguities()) <= 4
     else

--- a/test/groups/special_euclidean.jl
+++ b/test/groups/special_euclidean.jl
@@ -156,35 +156,33 @@ Random.seed!(10)
         end
 
         @testset "hat/vee" begin
-            shape_se =
-                Manifolds.ShapeSpecification(Manifolds.ArrayReshaper(), M.manifolds...)
-            p = Manifolds.prod_point(shape_se, tuple_pts[1]...)
-            V = Manifolds.prod_point(shape_se, tuple_X[1]...)
-            vexp = [V.parts[1]; vee(Rn, p.parts[2], V.parts[2])]
-            v = vee(G, p, V)
-            @test v ≈ vexp
-            @test hat(G, p, v) ≈ V
+            p = ProductRepr(tuple_pts[1]...)
+            X = ProductRepr(tuple_X[1]...)
+            Xexp = [X.parts[1]; vee(Rn, p.parts[2], X.parts[2])]
+            Xc = vee(G, p, X)
+            @test Xc ≈ Xexp
+            @test isapprox(G, p, hat(G, p, Xc), X)
 
-            v = vee(G, affine_matrix(G, p), screw_matrix(G, V))
-            @test v ≈ vexp
-            @test hat(G, affine_matrix(G, p), v) ≈ screw_matrix(G, V)
+            Xc = vee(G, affine_matrix(G, p), screw_matrix(G, X))
+            @test Xc ≈ Xexp
+            @test hat(G, affine_matrix(G, p), Xc) ≈ screw_matrix(G, X)
 
             e = Identity(G)
-            Ve = log_lie(G, p)
-            v = vee(G, e, Ve)
-            @test_throws ErrorException vee(M, e, Ve)
-            w = similar(v)
-            vee!(G, w, e, Ve)
-            @test isapprox(v, w)
-            @test_throws ErrorException vee!(M, w, e, Ve)
+            Xe = log_lie(G, p)
+            Xc = vee(G, e, Xe)
+            @test_throws ErrorException vee(M, e, Xe)
+            w = similar(Xc)
+            vee!(G, w, e, Xe)
+            @test isapprox(Xc, w)
+            @test_throws ErrorException vee!(M, w, e, Xe)
 
-            We = hat(G, e, v)
-            @test_throws ErrorException hat(M, e, v)
-            isapprox(G, e, Ve, We)
-            We2 = copy(G, p, V)
-            hat!(G, We2, e, v)
-            @test_throws ErrorException hat!(M, We, e, v)
-            @test isapprox(G, e, We, We2)
+            Ye = hat(G, e, Xc)
+            @test_throws ErrorException hat(M, e, Xc)
+            isapprox(G, e, Xe, Ye)
+            Ye2 = copy(G, p, X)
+            hat!(G, Ye2, e, Xc)
+            @test_throws ErrorException hat!(M, Ye, e, Xc)
+            @test isapprox(G, e, Ye, Ye2)
         end
     end
 

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -527,59 +527,85 @@ end
     end
 
     @testset "ProductRepr" begin
-        Ts = SizedVector{3,Float64}
-        Tr2 = SizedVector{2,Float64}
-        pts_sphere = [
-            convert(Ts, [1.0, 0.0, 0.0]),
-            convert(Ts, [0.0, 1.0, 0.0]),
-            convert(Ts, [0.0, 0.0, 1.0]),
-        ]
-        pts_r2 =
-            [convert(Tr2, [0.0, 0.0]), convert(Tr2, [1.0, 0.0]), convert(Tr2, [0.0, 0.1])]
-
-        pts = [ProductRepr(p[1], p[2]) for p in zip(pts_sphere, pts_r2)]
-        basis_types = (
-            DefaultOrthonormalBasis(),
-            ProjectedOrthonormalBasis(:svd),
-            get_basis(Mse, pts[1], DefaultOrthonormalBasis()),
-            DiagonalizingOrthonormalBasis(ProductRepr([0.0, 1.0, 0.0], [1.0, 0.0])),
-        )
-
         @test (@inferred convert(
             ProductRepr{Tuple{T,Float64,T} where T},
             ProductRepr(9, 10, 11),
         )) == ProductRepr(9, 10.0, 11)
 
-        test_manifold(
-            Mse,
-            pts,
-            test_injectivity_radius=false,
-            test_musical_isomorphisms=true,
-            test_tangent_vector_broadcasting=false,
-            test_forward_diff=false,
-            test_reverse_diff=false,
-            test_project_tangent=true,
-            test_project_point=true,
-            test_riesz_representer=true,
-            test_default_vector_transport=true,
-            vector_transport_methods=[
-                ProductVectorTransport(ParallelTransport(), ParallelTransport()),
-                ProductVectorTransport(SchildsLadderTransport(), SchildsLadderTransport()),
-                ProductVectorTransport(PoleLadderTransport(), PoleLadderTransport()),
-            ],
-            basis_types_vecs=(basis_types[1], basis_types[3], basis_types[4]),
-            basis_types_to_from=basis_types,
-            is_tangent_atol_multiplier=1,
-            exp_log_atol_multiplier=1,
-        )
-        @test number_eltype(pts[1]) === Float64
-        @test submanifold_component(Mse, pts[1], 1) === pts[1].parts[1]
-        @test submanifold_component(Mse, pts[1], Val(1)) === pts[1].parts[1]
-        @test submanifold_component(pts[1], 1) === pts[1].parts[1]
-        @test submanifold_component(pts[1], Val(1)) === pts[1].parts[1]
-        @test submanifold_components(Mse, pts[1]) === pts[1].parts
-        @test submanifold_components(pts[1]) === pts[1].parts
-        @test (@inferred ManifoldsBase._get_vector_cache_broadcast(pts[1])) === Val(false)
+        p = ProductRepr([1.0, 0.0, 0.0], [0.0, 0.0])
+        @test submanifold_component(Mse, p, 1) === p.parts[1]
+        @test submanifold_component(Mse, p, Val(1)) === p.parts[1]
+        @test submanifold_component(p, 1) === p.parts[1]
+        @test submanifold_component(p, Val(1)) === p.parts[1]
+        @test submanifold_components(Mse, p) === p.parts
+        @test submanifold_components(p) === p.parts
+    end
+
+    @testset "ArrayPartition" begin
+        p = ArrayPartition([1.0, 0.0, 0.0], [0.0, 0.0])
+        @test submanifold_component(Mse, p, 1) === p.x[1]
+        @test submanifold_component(Mse, p, Val(1)) === p.x[1]
+        @test submanifold_component(p, 1) === p.x[1]
+        @test submanifold_component(p, Val(1)) === p.x[1]
+        @test submanifold_components(Mse, p) === p.x
+        @test submanifold_components(p) === p.x
+    end
+
+    for TP in [ProductRepr, ArrayPartition]
+        @testset "TP=$TP" begin
+            Ts = SizedVector{3,Float64}
+            Tr2 = SizedVector{2,Float64}
+            pts_sphere = [
+                convert(Ts, [1.0, 0.0, 0.0]),
+                convert(Ts, [0.0, 1.0, 0.0]),
+                convert(Ts, [0.0, 0.0, 1.0]),
+            ]
+            pts_r2 = [
+                convert(Tr2, [0.0, 0.0]),
+                convert(Tr2, [1.0, 0.0]),
+                convert(Tr2, [0.0, 0.1]),
+            ]
+
+            pts = [TP(p[1], p[2]) for p in zip(pts_sphere, pts_r2)]
+            basis_types = (
+                DefaultOrthonormalBasis(),
+                ProjectedOrthonormalBasis(:svd),
+                get_basis(Mse, pts[1], DefaultOrthonormalBasis()),
+                DiagonalizingOrthonormalBasis(
+                    TP(SizedVector{3}([0.0, 1.0, 0.0]), SizedVector{2}([1.0, 0.0])),
+                ),
+            )
+
+            test_manifold(
+                Mse,
+                pts,
+                test_injectivity_radius=false,
+                test_musical_isomorphisms=true,
+                test_tangent_vector_broadcasting=false,
+                test_forward_diff=false,
+                test_reverse_diff=false,
+                test_project_tangent=true,
+                test_project_point=true,
+                test_riesz_representer=true,
+                test_default_vector_transport=true,
+                vector_transport_methods=[
+                    ProductVectorTransport(ParallelTransport(), ParallelTransport()),
+                    ProductVectorTransport(
+                        SchildsLadderTransport(),
+                        SchildsLadderTransport(),
+                    ),
+                    ProductVectorTransport(PoleLadderTransport(), PoleLadderTransport()),
+                ],
+                basis_types_vecs=(basis_types[1], basis_types[3], basis_types[4]),
+                basis_types_to_from=basis_types,
+                is_tangent_atol_multiplier=1,
+                exp_log_atol_multiplier=1,
+            )
+            @test number_eltype(pts[1]) === Float64
+
+            @test (@inferred ManifoldsBase._get_vector_cache_broadcast(pts[1])) ===
+                  Val(false)
+        end
     end
 
     @testset "vee/hat" begin
@@ -613,7 +639,7 @@ end
         Bc = get_basis(Mse, p, B)
         Bc_components_s = sprint.(show, "text/plain", Bc.data.parts)
         @test sprint(show, "text/plain", Bc) == """
-        DefaultOrthonormalBasis(ℝ) for a product manifold
+        DefaultOrthonormalBasis{ℝ, ManifoldsBase.TangentSpaceType} for a product manifold
         Basis for component 1:
         $(Bc_components_s[1])
         Basis for component 2:

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -641,7 +641,7 @@ end
         Bc = get_basis(Mse, p, B)
         Bc_components_s = sprint.(show, "text/plain", Bc.data.parts)
         @test sprint(show, "text/plain", Bc) == """
-        DefaultOrthonormalBasis{ℝ, ManifoldsBase.TangentSpaceType} for a product manifold
+        $(typeof(B)) for a product manifold
         Basis for component 1:
         $(Bc_components_s[1])
         Basis for component 2:

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -1,5 +1,7 @@
 include("../utils.jl")
 
+using RecursiveArrayTools: ArrayPartition
+
 struct NotImplementedReshaper <: Manifolds.AbstractReshaper end
 
 function parray(M, x)

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -83,6 +83,23 @@ end
         p1[Mse, Val(2)] = 2 * p3
         @test p1[Mse, Val(2)] == 2 * p3
 
+        p1ap = ArrayPartition([0.0, 1.0, 0.0], [0.0, 0.0])
+        @test get_component(Mse, p1ap, 1) == p1ap.x[1]
+        @test get_component(Mse, p1ap, Val(1)) == p1ap.x[1]
+        @test p1ap[Mse, 1] == p1ap.x[1]
+        @test p1ap[Mse, Val(1)] == p1ap.x[1]
+        @test p1ap[Mse, 1] isa Vector
+        @test p1ap[Mse, Val(1)] isa Vector
+        set_component!(Mse, p1ap, p2, 2)
+        @test get_component(Mse, p1ap, 2) == p2
+        p1ap[Mse, 2] = 2 * p2
+        @test p1ap[Mse, 2] == 2 * p2
+        p3 = [11.0, 15.0]
+        set_component!(Mse, p1ap, p3, Val(2))
+        @test get_component(Mse, p1ap, Val(2)) == p3
+        p1ap[Mse, Val(2)] = 2 * p3
+        @test p1ap[Mse, Val(2)] == 2 * p3
+
         shape_a_se = Manifolds.ShapeSpecification(Manifolds.ArrayReshaper(), M1, M2)
         pra1 = Manifolds.ProductArray(shape_a_se, [0.0, 1.0, 0.0, 0.0, 0.0])
         @test get_component(Mse, pra1, 1) == p1.parts[1]


### PR DESCRIPTION
This should make `ArrayPartition` work with `ProductManifold`. Some random points:
1. `println(io, "$(T()) for a product manifold")` doesn't work for `DiagonalizingOrthonormalBasis`, so I changed that.
2. I have no idea why `Ξ = [convert(T, V[:, i]) for i in 1:n]` worked without a conversion before but it doesn't now (specifically, without conversion `push!`ing vectors in `get_vectors` of `ProductManifold` fails:
```julia
function get_vectors(
    M::ProductManifold,
    p::ArrayPartition,
    B::CachedBasis{𝔽,<:AbstractBasis{𝔽},<:ProductBasisData},
) where {𝔽}
```