### PR TITLE
Introduces vector transport by projection on FixedRankMatrices.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.6.9"
+version = "0.6.10"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.6.10"
+version = "0.6.9"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -479,6 +479,19 @@ function Base.show(io::IO, ::MIME"text/plain", X::UMVTVector)
 end
 
 @doc raw"""
+    vector_transport_to(M::FixedRankMatrices, p, X, q, ::ProjectionTransport)
+
+Compute the vector transport of the tangent vector `X` at `p` to `q`,
+using the [`project`](@ref project(::FixedRankMatrices, ::Any...))
+of `X` to `q`.
+"""
+vector_transport_to!(::FixedRankMatrices, ::Any, ::Any, ::Any, ::ProjectionTransport)
+
+function vector_transport_to!(M::FixedRankMatrices, Y, p, X, q, ::ProjectionTransport)
+    return project!(M, Y, q, embed(M, p, X))
+end
+
+@doc raw"""
     zero_vector(M::FixedRankMatrices, p::SVDMPoint)
 
 Return a [`UMVTVector`](@ref) representing the zero tangent vector in the tangent space of

--- a/test/manifolds/fixed_rank.jl
+++ b/test/manifolds/fixed_rank.jl
@@ -192,6 +192,7 @@ include("../utils.jl")
                 test_tangent_vector_broadcasting=false, #broadcast not so easy for 3 matrix type
                 projection_atol_multiplier=15,
                 retraction_methods=[PolarRetraction()],
+                vector_transport_methods=[ProjectionTransport()],
                 mid_point12=nothing,
                 test_inplace=true,
             )

--- a/test/manifolds/fixed_rank.jl
+++ b/test/manifolds/fixed_rank.jl
@@ -4,12 +4,12 @@ include("../utils.jl")
     M = FixedRankMatrices(3, 2, 2)
     M2 = FixedRankMatrices(3, 2, 1)
     Mc = FixedRankMatrices(3, 2, 2, ℂ)
-    x = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0])
-    x2 = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0], 1)
-    v = UMVTVector([0.0 0.0; 0.0 0.0; 1.0 1.0], [1.0 0.0; 0.0 1.0], zeros(2, 2))
+    p = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0])
+    p2 = SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0], 1)
+    X = UMVTVector([0.0 0.0; 0.0 0.0; 1.0 1.0], [1.0 0.0; 0.0 1.0], zeros(2, 2))
     @test repr(M) == "FixedRankMatrices(3, 2, 2, ℝ)"
     @test repr(Mc) == "FixedRankMatrices(3, 2, 2, ℂ)"
-    @test sprint(show, "text/plain", x) == """
+    @test sprint(show, "text/plain", p) == """
     $(sprint(show, SVDMPoint{Matrix{Float64}, Vector{Float64}, Matrix{Float64}}))
     U factor:
      3×2 $(sprint(show, Matrix{Float64})):
@@ -24,7 +24,7 @@ include("../utils.jl")
      2×2 $(sprint(show, Matrix{Float64})):
       1.0  0.0
       0.0  1.0"""
-    @test sprint(show, "text/plain", v) == """
+    @test sprint(show, "text/plain", X) == """
     $(sprint(show, UMVTVector{Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}))
     U factor:
      3×2 $(sprint(show, Matrix{Float64})):
@@ -40,9 +40,9 @@ include("../utils.jl")
       0.0  0.0
       0.0  0.0"""
 
-    @test inner(M, x, v, v) == norm(M, x, v)^2
-    @test x == SVDMPoint(x.U, x.S, x.Vt)
-    @test v == UMVTVector(v.U, v.M, v.Vt)
+    @test inner(M, p, X, X) == norm(M, p, X)^2
+    @test p == SVDMPoint(p.U, p.S, p.Vt)
+    @test X == UMVTVector(X.U, X.M, X.Vt)
     @testset "Fixed Rank Matrices – Basics" begin
         @test representation_size(M) == (3, 2)
         @test get_embedding(M) == Euclidean(3, 2; field=ℝ)
@@ -51,46 +51,46 @@ include("../utils.jl")
         @test manifold_dimension(Mc) == 12
         @test !is_point(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2))
         @test_throws DomainError is_point(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2), true)
-        @test is_point(M2, x2)
+        @test is_point(M2, p2)
 
         @test !is_vector(
             M,
             SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0]),
             UMVTVector(zeros(2, 1), zeros(1, 2), zeros(2, 2)),
         )
-        @test !is_vector(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2), v)
-        @test_throws DomainError is_vector(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2), v, true)
-        @test !is_vector(M, x, UMVTVector(x.U, v.M, x.Vt, 2))
-        @test_throws DomainError is_vector(M, x, UMVTVector(x.U, v.M, x.Vt, 2), true)
-        @test !is_vector(M, x, UMVTVector(v.U, v.M, x.Vt, 2))
-        @test_throws DomainError is_vector(M, x, UMVTVector(v.U, v.M, x.Vt, 2), true)
+        @test !is_vector(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2), X)
+        @test_throws DomainError is_vector(M, SVDMPoint([1.0 0.0; 0.0 0.0], 2), X, true)
+        @test !is_vector(M, p, UMVTVector(p.U, X.M, p.Vt, 2))
+        @test_throws DomainError is_vector(M, p, UMVTVector(p.U, X.M, p.Vt, 2), true)
+        @test !is_vector(M, p, UMVTVector(X.U, X.M, p.Vt, 2))
+        @test_throws DomainError is_vector(M, p, UMVTVector(X.U, X.M, p.Vt, 2), true)
 
-        @test is_point(M, x)
-        @test is_vector(M, x, v)
+        @test is_point(M, p)
+        @test is_vector(M, p, X)
     end
     types = [[Matrix{Float64}, Vector{Float64}, Matrix{Float64}]]
     TEST_FLOAT32 && push!(types, [Matrix{Float32}, Vector{Float32}, Matrix{Float32}])
 
     for T in types
         @testset "Type $T" begin
-            y = retract(M, x, v, PolarRetraction())
-            z = SVDMPoint([1/sqrt(2) 1/sqrt(2); 1/sqrt(2) -1/sqrt(2); 0.0 0.0])
+            p2 = retract(M, p, X, PolarRetraction())
+            p3 = SVDMPoint([1/sqrt(2) 1/sqrt(2); 1/sqrt(2) -1/sqrt(2); 0.0 0.0])
             pts = []
-            for p in [x, y, z]
+            for p in [p, p2, p3]
                 push!(pts, SVDMPoint(convert.(T, [p.U, p.S, p.Vt])...))
             end
             for p in pts
                 @test is_point(M, p)
             end
             @testset "SVD AbstractManifoldPoint Basics" begin
-                s = svd(x.U * Diagonal(x.S) * x.Vt)
+                s = svd(p.U * Diagonal(p.S) * p.Vt)
                 x2 = SVDMPoint(s)
                 x3 = SVDMPoint(s.U, s.S, s.Vt)
-                @test SVDMPoint(x.U, x.S, x.Vt) == x
-                @test x.S == x2.S
-                @test x.U == x2.U
-                @test x.Vt == x2.Vt
-                @test x == x2
+                @test SVDMPoint(p.U, p.S, p.Vt) == p
+                @test p.S == x2.S
+                @test p.U == x2.U
+                @test p.Vt == x2.Vt
+                @test p == x2
                 @test x2.U == x3.U
                 @test x2.S == x3.S
                 @test x2.Vt == x3.Vt
@@ -108,17 +108,17 @@ include("../utils.jl")
                 @test y2.Vt == y3.Vt
                 @test y2 == y3
 
-                @test is_point(M, x)
-                xM = x.U * Diagonal(x.S) * x.Vt
+                @test is_point(M, p)
+                xM = p.U * Diagonal(p.S) * p.Vt
                 @test is_point(M, xM)
                 @test !is_point(M, xM[1:2, :])
                 @test_throws DomainError is_point(M, xM[1:2, :], true)
-                @test_throws DomainError is_point(FixedRankMatrices(3, 2, 1), x, true)
+                @test_throws DomainError is_point(FixedRankMatrices(3, 2, 1), p, true)
                 @test_throws DomainError is_point(FixedRankMatrices(3, 2, 1), xM, true)
-                xF1 = SVDMPoint(2 * x.U, x.S, x.Vt)
+                xF1 = SVDMPoint(2 * p.U, p.S, p.Vt)
                 @test !is_point(M, xF1)
                 @test_throws DomainError is_point(M, xF1, true)
-                xF2 = SVDMPoint(x.U, x.S, 2 * x.Vt)
+                xF2 = SVDMPoint(p.U, p.S, 2 * p.Vt)
                 @test !is_point(M, xF2)
                 @test_throws DomainError is_point(M, xF2, true)
                 # copyto
@@ -129,29 +129,29 @@ include("../utils.jl")
                 @test yC.Vt == y.Vt
                 # embed
                 N = get_embedding(M)
-                A = embed(M, x)
-                @test isapprox(N, A, x.U * Diagonal(x.S) * x.Vt)
+                A = embed(M, p)
+                @test isapprox(N, A, p.U * Diagonal(p.S) * p.Vt)
             end
             @testset "UMV TVector Basics" begin
-                w = UMVTVector(v.U, 2 * v.M, v.Vt)
-                @test v + w == UMVTVector(2 * v.U, 3 * v.M, 2 * v.Vt)
-                @test v - w == UMVTVector(0 * v.U, -v.M, 0 * v.Vt)
-                @test 2 * v == UMVTVector(2 * v.U, 2 * v.M, 2 * v.Vt)
-                @test v * 2 == UMVTVector(v.U * 2, v.M * 2, v.Vt * 2)
-                @test 2 \ v == UMVTVector(2 \ v.U, 2 \ v.M, 2 \ v.Vt)
-                @test v / 2 == UMVTVector(v.U / 2, v.M / 2, v.Vt / 2)
-                @test +v == v
-                @test -v == UMVTVector(-v.U, -v.M, -v.Vt)
-                w = UMVTVector(v.U, v.M, v.Vt)
-                @test v == w
-                w = allocate(v, number_eltype(v))
-                zero_vector!(M, w, x)
+                w = UMVTVector(X.U, 2 * X.M, X.Vt)
+                @test X + w == UMVTVector(2 * X.U, 3 * X.M, 2 * X.Vt)
+                @test X - w == UMVTVector(0 * X.U, -X.M, 0 * X.Vt)
+                @test 2 * X == UMVTVector(2 * X.U, 2 * X.M, 2 * X.Vt)
+                @test X * 2 == UMVTVector(X.U * 2, X.M * 2, X.Vt * 2)
+                @test 2 \ X == UMVTVector(2 \ X.U, 2 \ X.M, 2 \ X.Vt)
+                @test X / 2 == UMVTVector(X.U / 2, X.M / 2, X.Vt / 2)
+                @test +X == X
+                @test -X == UMVTVector(-X.U, -X.M, -X.Vt)
+                w = UMVTVector(X.U, X.M, X.Vt)
+                @test X == w
+                w = allocate(X, number_eltype(X))
+                zero_vector!(M, w, p)
                 oneP = SVDMPoint(one(zeros(3, 3)), ones(2), one(zeros(2, 2)), 2)
-                @test oneP == one(x)
+                @test oneP == one(p)
 
                 # copyto
                 w2 = allocate(w)
-                copyto!(M, w2, x, w)
+                copyto!(M, w2, p, w)
                 @test w.U == w2.U
                 @test w.M == w2.M
                 @test w.Vt == w2.Vt
@@ -162,19 +162,24 @@ include("../utils.jl")
                 # a new array
                 @test wc.U !== w.U
                 @test wc.U == w.U
-                wb = w .+ v .* 2
+                wb = w .+ X .* 2
                 @test wb isa UMVTVector
-                @test wb == w + v * 2
-                wb .= 2 .* w .+ v
-                @test wb == 2 * w + v
+                @test wb == w + X * 2
+                wb .= 2 .* w .+ X
+                @test wb == 2 * w + X
                 wb .= w
                 @test wb == w
                 # embed/project
                 N = get_embedding(M)
-                B = embed(M, x, v)
-                @test isapprox(N, x, B, x.U * v.M * x.Vt + v.U * x.Vt + x.U * v.Vt)
-                v2 = project(M, x, B)
-                @test isapprox(M, x, v, v2)
+                B = embed(M, p, X)
+                @test isapprox(N, p, B, p.U * X.M * p.Vt + X.U * p.Vt + p.U * X.Vt)
+                v2 = project(M, p, B)
+                @test isapprox(M, p, X, v2)
+            end
+            @testset "Projection Retraction and Vector transport" begin
+                X2 = vector_transport_to(M, p, X, p2, ProjectionTransport())
+                X2t = project(M, p2, embed(M, p, X))
+                @test isapprox(M, p, X2, X2t)
             end
             test_manifold(
                 M,
@@ -193,6 +198,8 @@ include("../utils.jl")
                 projection_atol_multiplier=15,
                 retraction_methods=[PolarRetraction()],
                 vector_transport_methods=[ProjectionTransport()],
+                vector_transport_retractions=[PolarRetraction()],
+                vector_transport_inverse_retractions=[PolarInverseRetraction()],
                 mid_point12=nothing,
                 test_inplace=true,
             )


### PR DESCRIPTION
This is just a small PR introducing vector transport by projection on fixed Rank matrices. Note that it embeds the UMTTVector in the embedding to project, this is necessary since UMTTVector is stored in a reduced form (i.e. for X at p the data from p is required to get the original matrix to represent X).