### PR TITLE
Make the current ODE-based exp solver only work in charts

### DIFF
--- a/src/atlases.jl
+++ b/src/atlases.jl
@@ -310,3 +310,57 @@ Compute the local metric tensor for vectors expressed in terms of coordinates
 in basis `B` on manifold `M`. The point `p` is not checked.
 """
 local_metric(::AbstractManifold, ::Any, ::InducedBasis)
+
+"""
+    ChartRetraction{TA<:AbstractAtlas,TI} <: AbstractRetractionMethod
+
+A type for retractions based on a chart.
+"""
+struct ChartRetraction{TA<:AbstractAtlas,TI} <: AbstractRetractionMethod
+    A::TA
+    i::TI
+end
+
+"""
+    retract(M, p, X, cr::ChartRetraction)
+
+Compute the chart-based retraction. The formula reads
+```math
+φ^{-1}(φ(p) + dφ(X))
+```
+where `dφ` computes coordinates in the [`InducedBasis`](@ref) of `φ`.
+"""
+retract(M, p, X, cr::ChartRetraction)
+
+function retract!(M, q, p, X, cr::ChartRetraction)
+    pc = get_parameters(M, cr.A, cr.i, p)
+    Xc = get_coordinates(M, p, X, InducedBasis(TangentSpaceType, cr.A, cr.i))
+    return get_point!(M, q, cr.A, cr.i, pc + Xc)
+end
+
+"""
+    ChartInverseRetraction{TA<:AbstractAtlas,TI} <: AbstractRetractionMethod
+
+A type for inverse retractions based on a chart.
+"""
+struct ChartInverseRetraction{TA<:AbstractAtlas,TI} <: AbstractInverseRetractionMethod
+    A::TA
+    i::TI
+end
+
+"""
+    inverse_retract(M, p, q, cr::ChartInverseRetraction)
+
+Compute the chart-based retraction. The formula reads
+```math
+dφ^{-1}(φ(q) - φ(p))
+```
+where `dφ` computes coordinates in the [`InducedBasis`](@ref) of `φ`.
+"""
+inverse_retract(M, p, q, cr::ChartInverseRetraction)
+
+function inverse_retract!(M, X, p, q, cr::ChartInverseRetraction)
+    pc = get_parameters(M, cr.A, cr.i, p)
+    qc = get_parameters(M, cr.A, cr.i, q)
+    return get_vector!(M, Xc, p, qc - pc, InducedBasis(TangentSpaceType, cr.A, cr.i))
+end

--- a/src/manifolds/ConnectionManifold.jl
+++ b/src/manifolds/ConnectionManifold.jl
@@ -157,8 +157,7 @@ exp(::AbstractConnectionManifold, ::Any...)
     i = get_chart_index(M, A, p)
     B = induced_basis(M, A, i, TangentSpace)
     sol = solve_exp_ode(M, p, X, tspan, B; dense=false, saveat=[1.0])
-    n = length(p)
-    return copyto!(q, sol.u[1][(n + 1):end])
+    return copyto!(q, sol)
 end
 
 """

--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -566,4 +566,92 @@ Return the zero vector in the tangent space of `x` on the [`Euclidean`](@ref)
 zero_vector(::Euclidean, ::Any...)
 zero_vector(::Euclidean{Tuple{}}, p::Number) = zero(p)
 
-zero_vector!(::Euclidean, v, ::Any) = fill!(v, 0)
+zero_vector!(::Euclidean, X, ::Any) = fill!(X, 0)
+
+const EuclideanLikeManifold{𝔽} = Union{
+    Euclidean{𝔽},
+    MetricManifold{𝔽,<:Euclidean{𝔽}},
+    ConnectionManifold{𝔽,<:Euclidean{𝔽}},
+}
+
+"""
+    TrivialEuclideanAtlas
+
+A trivial atlas for essentialy [`Euclidean`](@ref) manifolds with some metric.
+It has only one chart denoted `nothing`.
+"""
+struct TrivialEuclideanAtlas <: AbstractAtlas{ℝ} end
+
+get_default_atlas(::EuclideanLikeManifold) = TrivialEuclideanAtlas()
+
+get_chart_index(::EuclideanLikeManifold, ::TrivialEuclideanAtlas, p) = nothing
+
+function get_parameters!(::EuclideanLikeManifold, a, ::TrivialEuclideanAtlas, ::Nothing, p)
+    return copyto!(a, p)
+end
+
+function get_point!(::EuclideanLikeManifold, p, ::TrivialEuclideanAtlas, ::Nothing, a)
+    return copyto!(p, a)
+end
+
+const InducedTrivialEuclideanBasis{𝔽} =
+    InducedBasis{𝔽,TangentSpaceType,TrivialEuclideanAtlas,Nothing}
+
+function get_coordinates!(
+    M::EuclideanLikeManifold,
+    Y,
+    p,
+    X,
+    ::InducedTrivialEuclideanBasis{ℝ},
+)
+    S = representation_size(M)
+    PS = prod(S)
+    copyto!(Y, reshape(X, PS))
+    return Y
+end
+function get_coordinates!(
+    M::EuclideanLikeManifold{ℂ},
+    Y,
+    ::Any,
+    X,
+    ::InducedTrivialEuclideanBasis{ℂ},
+)
+    S = representation_size(M)
+    PS = prod(S)
+    Y .= [reshape(real.(X), PS)..., reshape(imag(X), PS)...]
+    return Y
+end
+
+function get_vector!(
+    M::EuclideanLikeManifold,
+    Y,
+    ::Any,
+    X,
+    ::InducedTrivialEuclideanBasis{ℝ},
+)
+    S = representation_size(M)
+    copyto!(Y, reshape(X, S))
+    return Y
+end
+function get_vector!(
+    ::EuclideanLikeManifold,
+    Y::AbstractVector,
+    ::Any,
+    X,
+    ::InducedTrivialEuclideanBasis{ℝ},
+)
+    copyto!(Y, X)
+    return Y
+end
+function get_vector!(
+    M::EuclideanLikeManifold{ℂ},
+    Y,
+    ::Any,
+    X,
+    ::InducedTrivialEuclideanBasis{ℂ},
+)
+    S = representation_size(M)
+    N = div(length(X), 2)
+    copyto!(Y, reshape(X[1:N] + im * X[(N + 1):end], S))
+    return Y
+end

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -9,6 +9,60 @@ struct TestEuclidean{N} <: AbstractManifold{ℝ} end
 struct TestEuclideanMetric <: AbstractMetric end
 struct TestScaledEuclideanMetric <: AbstractMetric end
 
+const TestEuclideanLike = Union{TestEuclidean,MetricManifold{ℝ,<:TestEuclidean}}
+
+Manifolds.get_default_atlas(::TestEuclideanLike) = Manifolds.TrivialEuclideanAtlas()
+
+function Manifolds.get_chart_index(
+    ::TestEuclideanLike,
+    ::Manifolds.TrivialEuclideanAtlas,
+    p,
+)
+    return nothing
+end
+
+Manifolds.representation_size(::TestEuclidean{N}) where {N} = (N,)
+
+function Manifolds.get_parameters!(
+    ::TestEuclideanLike,
+    a,
+    ::Manifolds.TrivialEuclideanAtlas,
+    ::Nothing,
+    p,
+)
+    return copyto!(a, p)
+end
+
+function Manifolds.get_point!(
+    ::TestEuclideanLike,
+    p,
+    ::Manifolds.TrivialEuclideanAtlas,
+    ::Nothing,
+    a,
+)
+    return copyto!(p, a)
+end
+
+function Manifolds.get_coordinates!(
+    ::TestEuclideanLike,
+    Y,
+    p,
+    X,
+    ::Manifolds.InducedTrivialEuclideanBasis{ℝ},
+)
+    return copyto!(Y, X)
+end
+
+function Manifolds.get_vector!(
+    ::TestEuclideanLike,
+    Y::AbstractVector,
+    ::Any,
+    X,
+    ::Manifolds.InducedTrivialEuclideanBasis{ℝ},
+)
+    return copyto!(Y, X)
+end
+
 Manifolds.manifold_dimension(::TestEuclidean{N}) where {N} = N
 function Manifolds.local_metric(
     M::MetricManifold{ℝ,<:TestEuclidean,<:TestEuclideanMetric},
@@ -359,7 +413,7 @@ end
             if !Sys.iswindows() || Sys.ARCH == :x86_64
                 @testset "numerically integrated geodesics for $vtype" begin
                     T = 0:0.1:1
-                    @test isapprox(
+                    @test_broken isapprox(
                         [sph_to_cart(yi...) for yi in geodesic(M, p, X, T)],
                         geodesic(S, pcart, Xcart, T);
                         atol=1e-3,


### PR DESCRIPTION
That's a quick sketch of the change discussed in https://github.com/JuliaManifolds/Manifolds.jl/pull/429 . This ODE-based implementation of `exp` only works on R^n with a metric (or a connection) so this makes it explicit. The scaled sphere test no longer works because it can't with this solver. `TrivialEuclideanAtlas` is introduced for cases where we just want R^n with a metric.

This isn't particularly well thought-through but may be a good direction.