### PR TITLE
Add embed! function for Rotation manifolds

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,6 +6,12 @@
             "orcid": "0000-0002-6284-3033"
         },
         {
+            "affiliation": "EMBL Heidelberg",
+            "name": "Ahlmann-Eltze, Constantin",
+            "type": "Other",
+            "orcid": "0000-0002-3762-068X"
+        },
+        {
             "affiliation": "KU Leuven",
             "name": "Dewaele, Nick",
             "orcid": "0000-0002-5558-4782",

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/docs/src/manifolds/rotations.md
+++ b/docs/src/manifolds/rotations.md
@@ -14,7 +14,7 @@ Tangent spaces at different points are different vector spaces.
 
 Let $L_R: \mathrm{SO}(n) → \mathrm{SO}(n)$ where $R ∈ \mathrm{SO}(n)$ be the left-multiplication by $R$, that is $L_R(S) = RS$.
 The tangent space at rotation $R$, $T_R \mathrm{SO}(n)$, is related to the tangent space at the identity rotation $I_n$ by the differential of $L_R$ at identity, $(\mathrm{d}L_R)_{I_n} : T_{I_n} \mathrm{SO}(n) → T_R \mathrm{SO}(n)$.
-For a tangent vector at the identity rotation $X ∈ T_{I_n} \mathrm{SO}(n)$ the matrix representation of the corresponding tangent vector $Y$ at a rotation $R$ can be obtained by matrix multiplication: $Y = RX ∈ T_R \mathrm{SO}(n)$.
+To convert the tangent vector representation at the identity rotation $X ∈ T_{I_n} \mathrm{SO}(n)$ (i.e., the default) to the matrix representation of the corresponding tangent vector $Y$ at a rotation $R$ use the [`embed`](@ref embed(::Manifolds.Rotations, :Any...)) which implements the following multiplication: $Y = RX ∈ T_R \mathrm{SO}(n)$.
 You can compare the functions [`log`](@ref log(::Manifolds.Rotations, :Any...)) and [`exp`](@ref exp(::Manifolds.Rotations, ::Any...)) to see how it works in practice.
 
 ```@autodocs

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -99,6 +99,26 @@ function check_vector(M::Rotations{N}, p, X; kwargs...) where {N}
     return check_point(SkewSymmetricMatrices(N), X; kwargs...)
 end
 
+
+@doc raw"""
+    embed(M::Rotations{N}, p, X)
+
+Embed the tangent vector `X` at point `p` in `M` from
+its Lie algebra representation (set of skew matrices) into the
+Riemannian submanifold representation
+
+The formula reads
+```math
+X_{\text{embedded}} = p * X
+```
+"""
+embed(::Rotations{N}, p, X) where {N}
+
+function embed!(::Rotations{N}, Y, p, X) where {N}
+    return mul!(Y, p, X)
+end
+
+
 @doc raw"""
     cos_angles_4d_rotation_matrix(R)
 

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -99,7 +99,6 @@ function check_vector(M::Rotations{N}, p, X; kwargs...) where {N}
     return check_point(SkewSymmetricMatrices(N), X; kwargs...)
 end
 
-
 @doc raw"""
     embed(M::Rotations{N}, p, X)
 
@@ -117,7 +116,6 @@ embed(::Rotations{N}, p, X) where {N}
 function embed!(::Rotations{N}, Y, p, X) where {N}
     return mul!(Y, p, X)
 end
-
 
 @doc raw"""
     cos_angles_4d_rotation_matrix(R)

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -113,7 +113,7 @@ X_{\text{embedded}} = p * X
 """
 embed(::Rotations, p, X)
 
-function embed!(::Rotations{N}, Y, p, X) where {N}
+function embed!(::Rotations, Y, p, X)
     return mul!(Y, p, X)
 end
 

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -111,7 +111,7 @@ The formula reads
 X_{\text{embedded}} = p * X
 ```
 """
-embed(::Rotations{N}, p, X) where {N}
+embed(::Rotations, p, X)
 
 function embed!(::Rotations{N}, Y, p, X) where {N}
     return mul!(Y, p, X)

--- a/test/manifolds/rotations.jl
+++ b/test/manifolds/rotations.jl
@@ -204,18 +204,15 @@ include("../utils.jl")
         @test is_point(M, x3, true)
     end
     @testset "Convert from Lie algebra representation of tangents to Riemannian submanifold representation" begin
-        skew(M) = (M - M') / 2
-        M = Manifolds.Rotations(4)
-        rng = MersenneTwister(1)
-        p = project(M, randn(rng, (4, 4)))
-        x = skew(randn(rng, (4, 4)))
+        M = Manifolds.Rotations(3)
+        p = project(M, collect(reshape(1.0:9.0, (3, 3))))
+        x = [[0, -1, 3] [1, 0, 2] [-3, -2, 0]]
         @test is_vector(M, p, x, true)
-        embedded_x = embed(M, p, x)
-        @test embedded_x == p * x
-        res = zeros((4, 4))
-        embed!(M, res, p, x)
-        @test res == p * x
-        @test embedded_x ≈ p * skew(p' * embedded_x)
+        @test embed(M, p, x) == p * x
+        Y = zeros((3,3))
+        embed!(M, Y, p, x)
+        @test Y == p * x
+        @test Y ≈ p * (p'Y - Y'p)/2
     end
     @testset "Edge cases of Rotations" begin
         @test_throws OutOfInjectivityRadiusError inverse_retract(

--- a/test/manifolds/rotations.jl
+++ b/test/manifolds/rotations.jl
@@ -203,6 +203,20 @@ include("../utils.jl")
         x3 = project(M, randn(rng, 3, 3))
         @test is_point(M, x3, true)
     end
+    @testset "Convert from Lie algebra representation of tangents to Riemannian submanifold representation" begin
+        skew(M) = (M - M')/2
+        M = Manifolds.Rotations(4)
+        rng = MersenneTwister(1)
+        p = project(M, randn(rng, (4,4)))
+        x = skew(randn(rng, (4,4)))
+        @test is_vector(M, p, x, true)
+        embedded_x = embed(M, p, x)
+        @test embedded_x == p * x
+        res = zeros((4,4))
+        embed!(M, res, p, x)
+        @test res == p * x
+        @test embedded_x ≈ p * skew(p' * embedded_x)
+    end
     @testset "Edge cases of Rotations" begin
         @test_throws OutOfInjectivityRadiusError inverse_retract(
             Rotations(2),

--- a/test/manifolds/rotations.jl
+++ b/test/manifolds/rotations.jl
@@ -209,10 +209,10 @@ include("../utils.jl")
         x = [[0, -1, 3] [1, 0, 2] [-3, -2, 0]]
         @test is_vector(M, p, x, true)
         @test embed(M, p, x) == p * x
-        Y = zeros((3,3))
+        Y = zeros((3, 3))
         embed!(M, Y, p, x)
         @test Y == p * x
-        @test Y ≈ p * (p'Y - Y'p)/2
+        @test Y ≈ p * (p'Y - Y'p) / 2
     end
     @testset "Edge cases of Rotations" begin
         @test_throws OutOfInjectivityRadiusError inverse_retract(

--- a/test/manifolds/rotations.jl
+++ b/test/manifolds/rotations.jl
@@ -204,15 +204,15 @@ include("../utils.jl")
         @test is_point(M, x3, true)
     end
     @testset "Convert from Lie algebra representation of tangents to Riemannian submanifold representation" begin
-        skew(M) = (M - M')/2
+        skew(M) = (M - M') / 2
         M = Manifolds.Rotations(4)
         rng = MersenneTwister(1)
-        p = project(M, randn(rng, (4,4)))
-        x = skew(randn(rng, (4,4)))
+        p = project(M, randn(rng, (4, 4)))
+        x = skew(randn(rng, (4, 4)))
         @test is_vector(M, p, x, true)
         embedded_x = embed(M, p, x)
         @test embedded_x == p * x
-        res = zeros((4,4))
+        res = zeros((4, 4))
         embed!(M, res, p, x)
         @test res == p * x
         @test embedded_x ≈ p * skew(p' * embedded_x)


### PR DESCRIPTION
Here is my first draft of the `embed!` function for rotation manifolds as discussed on the slack channel.
I also included some documentation, but no unit tests, because I am still struggling a bit with package development in Julia.