### PR TITLE
Introduce EmbeddedBackend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/docs/src/features/differentiation.md
+++ b/docs/src/features/differentiation.md
@@ -33,3 +33,9 @@ Modules = [Manifolds]
 Pages = ["differentiation/riemannian_diff.jl"]
 Order = [:type, :function, :constant]
 ```
+
+```@autodocs
+Modules = [Manifolds]
+Pages = ["differentiation/embedded_diff.jl"]
+Order = [:type, :function, :constant]
+```

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -713,6 +713,7 @@ export get_basis,
 # differentiation
 export AbstractDiffBackend,
     AbstractRiemannianDiffBackend,
+    ExplicitEmbeddedBackend,
     FiniteDifferencesBackend,
     TangentDiffBackend,
     RiemannianProjectionBackend

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -201,6 +201,7 @@ include("utils.jl")
 include("product_representations.jl")
 include("differentiation/differentiation.jl")
 include("differentiation/riemannian_diff.jl")
+include("differentiation/embedded_diff.jl")
 
 # Main Meta Manifolds
 include("manifolds/ConnectionManifold.jl")

--- a/src/differentiation/embedded_diff.jl
+++ b/src/differentiation/embedded_diff.jl
@@ -1,0 +1,39 @@
+"""
+    EmbeddedBackend <: AbstractDiffBackend
+
+A type to specify / use differentiation by definiing the functions in the embedding
+
+# Constructor
+    EmbeddedBackend(; derivative=missing gradient=missing, jacobian=missing)
+"""
+struct EmbeddedBackend{D,G,J} <: AbstractDiffBackend
+    gradient::G
+    derivative::D
+    jacobian::J
+end
+
+FiniteDiffBackend() = FiniteDiffBackend(Val(:central))
+
+function _derivative(f, p, e::EmbeddedBackend) where {Method}
+    return e.derivative(p)
+end
+
+function _derivative(f, p, ::EmbeddedBackend{Missing})
+    throw(MissingException("The provided Embedded backend does not provide a derivative"))
+end
+
+function _gradient(f, p, e::EmbeddedBackend) where {Method}
+    return e.gradient(p)
+end
+
+function _gradient(f, p, ::EmbeddedBackend{D,Missing}) where {D}
+    throw(MissingException("The provided Embedded backend does not provide a gradient"))
+end
+
+function _jacobian(f, p, e::EmbeddedBackend)
+    return e.jacobian(p)
+end
+
+function _jacobian(f, p, ::EmbeddedBackend{D,G,Missing}) where {D,G}
+    throw(MissingException("The provided Embedded backend does not provide a jacobian"))
+end


### PR DESCRIPTION
Solves #454. 

The `EmbeddedBackend´ contains the gradient (derivative, jacobian) of a function $f$ defined on a manifold that describe its gradient (derivative, jacobian) as a function extended into the embedding. Similar t Euclidean tools available they hence return Euclidean gradients (derivatives, Jacobins) that have to be converted.

* We should find a way to maybe also introduce mutating variants 
* Is the design ok this way?
* Yes, documentation is missing.