### PR TITLE
Fix `allocate_coordinates` for `ArrayPartition`

### DIFF
--- a/assets/projection_illustration.jl
+++ b/assets/projection_illustration.jl
@@ -43,7 +43,7 @@ tp = @pgf Axis({
     axis_equal,
     xmin = -1.7,
     xmax = 1.7,
-    ymin = -.25,
+    ymin = -0.25,
     ymax = 1.4,
     scale = 1.6,
 })

--- a/assets/retraction_illustration.jl
+++ b/assets/retraction_illustration.jl
@@ -41,7 +41,7 @@ tp = @pgf Axis({
     axis_equal,
     xmin = -1.7,
     xmax = 1.7,
-    ymin = -.25,
+    ymin = -0.25,
     ymax = 1.4,
     scale = 1.6,
 })

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -5,6 +5,7 @@ import ManifoldsBase:
     _read,
     _write,
     allocate,
+    allocate_coordinates,
     allocate_result,
     allocate_result_type,
     allocation_promotion_function,

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -135,6 +135,10 @@ function ProductVectorTransport(methods::AbstractVectorTransportMethod...)
     return ProductVectorTransport{typeof(methods)}(methods)
 end
 
+function allocate_coordinates(M::ProductManifold, p::ArrayPartition, T, n::Int)
+    return allocate_coordinates(M, p.x[1], T, n)
+end
+
 """
     change_representer(M::ProductManifold, ::AbstractMetric, p, X)
 

--- a/src/manifolds/ProductManifold.jl
+++ b/src/manifolds/ProductManifold.jl
@@ -135,7 +135,7 @@ function ProductVectorTransport(methods::AbstractVectorTransportMethod...)
     return ProductVectorTransport{typeof(methods)}(methods)
 end
 
-function allocate_coordinates(M::ProductManifold, p::ArrayPartition, T, n::Int)
+function allocate_coordinates(M::AbstractManifold, p::ArrayPartition, T, n::Int)
     return allocate_coordinates(M, p.x[1], T, n)
 end
 

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -435,12 +435,14 @@ using RecursiveArrayTools: ArrayPartition
         # make sure `get_coordinates` does not return an `ArrayPartition`
         p1 = ProductRepr([0.0, 1.0, 0.0], [0.0, 0.0])
         X1 = ProductRepr([1.0, 0.0, -1.0], [1.0, 0.0])
-        c = get_coordinates(Mse, p1, X1, DefaultOrthonormalBasis())
+        Tp1Mse = TangentSpaceAtPoint(Mse, p1)
+        c = get_coordinates(Tp1Mse, p1, X1, DefaultOrthonormalBasis())
         @test c isa Vector
 
         p1ap = ArrayPartition([0.0, 1.0, 0.0], [0.0, 0.0])
         X1ap = ArrayPartition([1.0, 0.0, -1.0], [1.0, 0.0])
-        cap = get_coordinates(Mse, p1ap, X1ap, DefaultOrthonormalBasis())
+        Tp1apMse = TangentSpaceAtPoint(Mse, p1ap)
+        cap = get_coordinates(Tp1apMse, p1ap, X1ap, DefaultOrthonormalBasis())
         @test cap isa Vector
     end
 

--- a/test/manifolds/product_manifold.jl
+++ b/test/manifolds/product_manifold.jl
@@ -431,6 +431,19 @@ using RecursiveArrayTools: ArrayPartition
         @test isapprox(X, X2)
     end
 
+    @testset "get_coordinates" begin
+        # make sure `get_coordinates` does not return an `ArrayPartition`
+        p1 = ProductRepr([0.0, 1.0, 0.0], [0.0, 0.0])
+        X1 = ProductRepr([1.0, 0.0, -1.0], [1.0, 0.0])
+        c = get_coordinates(Mse, p1, X1, DefaultOrthonormalBasis())
+        @test c isa Vector
+
+        p1ap = ArrayPartition([0.0, 1.0, 0.0], [0.0, 0.0])
+        X1ap = ArrayPartition([1.0, 0.0, -1.0], [1.0, 0.0])
+        cap = get_coordinates(Mse, p1ap, X1ap, DefaultOrthonormalBasis())
+        @test cap isa Vector
+    end
+
     @testset "Basis printing" begin
         p = ProductRepr([1.0, 0.0, 0.0], [1.0, 0.0])
         B = DefaultOrthonormalBasis()


### PR DESCRIPTION
A small fix so that `get_coordinates` doesn't return `ArrayPartition` back.