### PR TITLE
Fix embedding of Rotations.

### DIFF
--- a/docs/src/manifolds/rotations.md
+++ b/docs/src/manifolds/rotations.md
@@ -8,7 +8,18 @@ R^{\mathrm{T}}R = I_n, \det(R) = 1 \bigr\}$
 The Lie group $\mathrm{SO}(n)$ is a subgroup of the orthogonal group $\mathrm{O}(n)$ and also known as the special orthogonal group or the set of rotations group.
 See also [`SpecialOrthogonal`](@ref), which is this manifold equipped with the group operation.
 
-Tangent vectors are represented by elements of the corresponding Lie algebra, which is the tangent space at the identity element.
+A tangent space to a point ``p ∈ \mathrm{SO}(n)`` is given by
+
+```math
+T_p\mathrm{SO}(n) = \{X : X=pY,\qquad Y=-Y^{\mathrm{T}}\},
+```
+
+i.e. all vectors that are a product of a skew symmetric matrix multiplied with ``p``.
+
+Since the orthogonal matrices ``\mathrm{SO}(n)`` are a Lie group, tangent vectors can also be
+represented by elements of the corresponding Lie algebra, which is the tangent space at the identity element.
+In the notation above, this means we just store the component ``Y`` of ``X``.
+
 This convention allows for more efficient operations on tangent vectors.
 Tangent spaces at different points are different vector spaces.
 

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -38,7 +38,9 @@ function NormalRotationDistribution(
     return NormalRotationDistribution{TResult,typeof(M),typeof(d)}(M, d)
 end
 
-active_traits(f, ::Rotations, args...) = merge_traits(IsEmbeddedManifold())
+function active_traits(f, ::Rotations, args...)
+    return merge_traits(IsIsometricEmbeddedManifold(), IsDefaultMetric(EuclideanMetric()))
+end
 
 @doc raw"""
     angles_4d_skew_sym_matrix(A)
@@ -174,7 +176,7 @@ The algorithm used is a more numerically stable form of those proposed in
 """
 exp(::Rotations, ::Any...)
 
-exp!(M::Rotations, q, p, X) = copyto!(q, p * exp(X))
+exp!(::Rotations, q, p, X) = copyto!(q, p * exp(X))
 function exp!(M::Rotations{2}, q, p, X)
     @assert size(q) == (2, 2)
     θ = get_coordinates(M, p, X, DefaultOrthogonalBasis())[1]


### PR DESCRIPTION
The Rotations manifold actually inherits its metric by restricting the metric from the embedding (n-by-n matrices with default Euclidean metric) to the tangent space (even independent of which representation of tangent vectors). So this PR changes that. It also adds a note to the docs _which_ tangent vector representation we use.