### PR TITLE
Stabilise log for BW and GBW

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/SymmetricPositiveDefiniteBuresWasserstein.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteBuresWasserstein.jl
@@ -53,7 +53,7 @@ end
 Compute the distance with respect to the [`BuresWassersteinMetric`](@ref) on [`SymmetricPositiveDefinite`](@ref) matrices, i.e.
 
 ```math
-d(p,q) = 
+d(p,q) =
     \operatorname{tr}(p) + \operatorname{tr}(q) - 2\operatorname{tr}\Bigl( (p^{\frac{1}{2}}qp^{\frac{1}{2}} \bigr)^\frac{1}{2} \Bigr),
 ```
 
@@ -133,6 +133,6 @@ function log!(
     p,
     q,
 )
-    X .= sqrt(p * q) + sqrt(q * p) - 2 * p
+    X .= sqrt(Symmetric(p * q)) + sqrt(Symmetric(q * p)) - 2 * p
     return X
 end

--- a/src/manifolds/SymmetricPositiveDefiniteGeneralizedBuresWasserstein.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteGeneralizedBuresWasserstein.jl
@@ -141,6 +141,6 @@ function log!(
     m = M.metric.M
     lum = lu(m)
     lum_p_lum = lum \ p / lum
-    X .= Symmetric(m * sqrt(lum_p_lum * q) + sqrt(q * lum_p_lum) * m) - 2 * p
+    X .= m * sqrt(Symmetric(lum_p_lum * q)) + sqrt(Symmetric((q * lum_p_lum) * m)) - 2 * p
     return X
 end

--- a/src/manifolds/SymmetricPositiveDefiniteGeneralizedBuresWasserstein.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteGeneralizedBuresWasserstein.jl
@@ -125,10 +125,8 @@ Compute the logarithmic map on [`SymmetricPositiveDefinite`](@ref) with respect 
 the [`BuresWassersteinMetric`](@ref) given by
 
 ```math
-    \log_p(q) = M(M^{-1}pM^{-1}q)^{\frac{1}{2}} + (qM^{-1}pM^{-1})^{\frac{1}{2}}M^{-1} - 2 p
+    \log_p(q) = M(M^{-1}pM^{-1}q)^{\frac{1}{2}} + (qM^{-1}pM^{-1})^{\frac{1}{2}}M - 2 p.
 ```
-
-where ``q=L_p(X)`` denotes the Lyapunov operator, i.e. it solves ``pq + qp = X``.
 """
 log(::MetricManifold{ℝ,SymmetricPositiveDefinite,GeneralizedBuresWassersteinMetric}, p, q)
 
@@ -141,6 +139,6 @@ function log!(
     m = M.metric.M
     lum = lu(m)
     lum_p_lum = lum \ p / lum
-    X .= m * sqrt(Symmetric(lum_p_lum * q)) + sqrt(Symmetric((q * lum_p_lum) * m)) - 2 * p
+    X .= real.(Symmetric(m * sqrt(lum_p_lum * q) + sqrt(q * lum_p_lum) * m) - 2 * p)
     return X
 end


### PR DESCRIPTION
When using the new BuresWasserstein we noticed that the log somethimes returned complex values. This PR avoids the complex values (as numerical artefacts) by passing symmetrized matrices to `sqrt`.