### PR TITLE
Fix exp! fallback on Translation group

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/groups/translation_group.jl
+++ b/src/groups/translation_group.jl
@@ -20,7 +20,7 @@ end
 
 @inline function active_traits(f, M::TranslationGroup, args...)
     if is_metric_function(f)
-        #pass to Rotations by default - but keep Group Decorator for the retraction
+        #pass to Euclidean by default - but keep Group Decorator for the retraction
         return merge_traits(IsGroupManifold(M.op), IsExplicitDecorator())
     else
         return merge_traits(
@@ -28,7 +28,7 @@ end
             HasBiinvariantMetric(),
             IsDefaultMetric(EuclideanMetric()),
             active_traits(f, M.manifold, args...),
-            IsExplicitDecorator(), #pass to Rotations by default/last fallback
+            IsExplicitDecorator(), #pass to Euclidean by default/last fallback
         )
     end
 end

--- a/src/groups/translation_group.jl
+++ b/src/groups/translation_group.jl
@@ -21,11 +21,16 @@ end
 @inline function active_traits(f, M::TranslationGroup, args...)
     return merge_traits(
         IsGroupManifold(M.op),
-        IsDefaultMetric(EuclideanMetric()),
         HasBiinvariantMetric(),
         active_traits(f, M.manifold, args...),
         IsExplicitDecorator(),
     )
+end
+# for exp! just pass down, the M.manifold traits would introduce MetricManifold which triggers
+# the ODE solver and yields a domain error, cf.
+# https://github.com/JuliaManifolds/Manifolds.jl/issues/483
+@inline function active_traits(::typeof(exp!), M::TranslationGroup, args...)
+    return merge_traits(IsExplicitDecorator())
 end
 
 identity_element!(::TranslationGroup, p) = fill!(p, 0)

--- a/test/groups/translation_group.jl
+++ b/test/groups/translation_group.jl
@@ -18,6 +18,12 @@ include("group_utils.jl")
         @test log_lie(G, Identity(G)) == zeros(2, 3) # log_lie with Identity on Addition group.
         pts = [reshape(i:(i + 5), (2, 3)) for i in 1:3]
         vpts = [reshape(-2:3, (2, 3)), reshape(-1:4, (2, 3))]
+        # test fallback exp/exp! that the fallback works correctly, cf.
+        # https://github.com/JuliaManifolds/Manifolds.jl/issues/483
+        q = exp(G, pts[1], vpts[1])
+        q2 = copy(G, pts[1])
+        exp!(G, q2, pts[1], vpts[1])
+        @test q == q2
         for T in types
             gpts = convert.(T, pts)
             vgpts = convert.(T, vpts)


### PR DESCRIPTION
To not fall back to the ODE solver (just because Euclidean is a `MetricManifold` but the ExplicitDecorator comes later).
Fixes #483.

The one thing to discuss here is, whether this should be done for all group manifolds (i.e. to have a special just-fallback-exp!)?
What do you think @mateuszbaran ?