### PR TITLE
Add unitary and orthogonal manifolds and Lie groups

### DIFF
--- a/docs/src/misc/notation.md
+++ b/docs/src/misc/notation.md
@@ -13,6 +13,7 @@ Within the documented functions, the utf8 symbols are used whenever possible, as
 | ``\operatorname{Ad}_p(X)`` | adjoint action of element ``p`` of a Lie group on the element ``X`` of the corresponding Lie algebra | | |
 | ``\times`` | Cartesian product of two manifolds | | see [`ProductManifold`](@ref) |
 | ``^{\wedge}`` | (n-ary) Cartesian power of a manifold | | see [`PowerManifold`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/manifolds.html#ManifoldsBase.PowerManifold) |
+| ``\cdot^\mathrm{H}`` | conjugate/Hermitian transposed | |
 | ``a`` | coordinates of a point in a chart | | see [`get_parameters`](@ref) |
 | ``\frac{\mathrm{D}}{\mathrm{d}t}`` | covariant derivative of a vector field ``X(t)`` | | |
 | ``T^*_p \mathcal M`` | the cotangent space at ``p`` | | |

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -345,9 +345,11 @@ include("manifolds/SymmetricPositiveDefiniteLinearAffine.jl")
 include("manifolds/SymmetricPositiveDefiniteLogCholesky.jl")
 include("manifolds/SymmetricPositiveDefiniteLogEuclidean.jl")
 include("manifolds/SymmetricPositiveSemidefiniteFixedRank.jl")
-include("manifolds/Tucker.jl")
 include("manifolds/Symplectic.jl")
 include("manifolds/SymplecticStiefel.jl")
+include("manifolds/Tucker.jl")
+include("manifolds/Unitary.jl")
+include("manifolds/Orthogonal.jl")
 
 # Product or power based manifolds
 include("manifolds/Torus.jl")
@@ -374,6 +376,10 @@ include("groups/semidirect_product_group.jl")
 include("groups/general_linear.jl")
 include("groups/special_linear.jl")
 include("groups/translation_group.jl")
+# TODO
+# include("groups/unitary.jl")
+# include("groups/orthogonal.jl")
+# include("groups/special_unitary.jl")
 include("groups/special_orthogonal.jl")
 include("groups/circle_group.jl")
 include("groups/heisenberg.jl")
@@ -467,6 +473,7 @@ export Euclidean,
     MultinomialMatrices,
     MultinomialSymmetric,
     Oblique,
+    OrthogonalMatrices,
     PositiveArrays,
     PositiveMatrices,
     PositiveNumbers,
@@ -695,6 +702,7 @@ export AbstractGroupAction,
     LeftAction,
     LeftInvariantMetric,
     MultiplicationOperation,
+    OrthogonalMatrices,
     ProductGroup,
     ProductOperation,
     RealCircleGroup,
@@ -705,8 +713,8 @@ export AbstractGroupAction,
     SpecialEuclidean,
     SpecialLinear,
     SpecialOrthogonal,
-    TranslationGroup,
-    TranslationAction
+    SpecialUnitary
+TranslationGroup, TranslationAction, UnitaryMatrices
 export AbstractInvarianceTrait
 export IsMetricManifold, IsConnectionManifold
 export IsGroupManifold,

--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -204,6 +204,8 @@ function identity_element(::TraitList{<:IsGroupManifold}, G::AbstractDecoratorMa
     return identity_element!(BG, q)
 end
 
+Base.adjoint(e::Identity) = e
+
 function check_size(
     ::TraitList{<:IsGroupManifold{O}},
     M::AbstractDecoratorManifold,
@@ -541,7 +543,7 @@ function compose!(
     return e
 end
 
-transpose(e::Identity) = e
+Base.transpose(e::Identity) = e
 
 @doc raw"""
     hat(M::AbstractDecoratorManifold{𝔽,O}, ::Identity{O}, Xⁱ) where {𝔽,O<:AbstractGroupOperation}

--- a/src/manifolds/Orthogonal.jl
+++ b/src/manifolds/Orthogonal.jl
@@ -1,0 +1,13 @@
+@doc raw"""
+     OrthogonalMatrices{n}
+
+The manifold of (real) orthogonal matrices ``\mathrm{O}(n)``.
+This is the special case of {`UnitaryMatrices`}(@ref) over the reals.
+
+    OrthogonalMatrices(n)
+
+The constructor is equivalent to calling [`Unitary(n,ℝ)`](@ref).
+"""
+const OrthogonalMatrices{n} = UnitaryMatrices{n,ℝ}
+
+OrthogonalMatrices(n) = OrthogonalMatrices{n}()

--- a/src/manifolds/Rotations.jl
+++ b/src/manifolds/Rotations.jl
@@ -89,8 +89,7 @@ end
     check_vector(M, p, X; kwargs... )
 
 Check whether `X` is a tangent vector to `p` on the [`Rotations`](@ref)
-space `M`, i.e. after [`check_point`](@ref)`(M,p)`, `X` has to be of same
-dimension and orthogonal to `p`.
+space `M`, i.e. after [`check_point`](@ref)`(M,p)`, `X` has to be skew symmetric.
 The tolerance for the last test can be set using the `kwargs...`.
 """
 function check_vector(M::Rotations{N}, p, X; kwargs...) where {N}
@@ -136,10 +135,9 @@ By convention, the returned values are sorted in increasing order. See
 [`angles_4d_skew_sym_matrix`](@ref).
 """
 function cos_angles_4d_rotation_matrix(R)
-    trR = tr(R)
-    a = trR / 4
-    b = sqrt(clamp(tr((R .- transpose(R))^2) / 16 - a^2 + 1, 0, Inf))
-    return (a + b, a - b)
+    a = tr(R)
+    b = sqrt(clamp(2 * dot(transpose(R), R) - a^2 + 8, 0, Inf))
+    return ((a + b) / 4, (a - b) / 4)
 end
 
 @doc raw"""

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -1,0 +1,132 @@
+@doc raw"""
+    UnitaryMatrices{n,𝔽} <: AbstractManifold{𝔽}
+
+The manifold ``U(n)`` of ``n×n`` matrices over the field ``\mathbb F``, ``\mathbb C`` by
+default, such that
+
+``p^{\mathrm{H}p = \mathrm{I}_n,``
+
+where ``\mathrm{I}_n`` is the ``n×n`` identity matrix.
+An alternative characterisation is that ``\lVert \det(p) \rVert = 1``.
+
+The tangent spaces are given by
+
+```math
+    T_pU(n) \coloneqq \bigl\{
+    X \big| pY \text{ where } Y \text{ is skew symmetric, i. e. } Y = -Y^{\mathrm{H}}
+    \bigr\}
+```
+
+But note that tangent vectors are represented in the Lie algebra, i.e. just using ``Y`` in the representation above.
+
+# Constructor
+     Unitary(n, 𝔽=ℂ)
+
+Constructs ``\mathrm{U}(n, 𝔽)``, see also [`OrthogonalMatrices(n)`](@ref) for the real-valued case.
+"""
+struct UnitaryMatrices{n,𝔽} <: AbstractManifold{𝔽} end
+
+UnitaryMatrices(n::Int, field=ℂ) = UnitaryMatrices{n,field}()
+
+function active_traits(f, ::UnitaryMatrices, args...)
+    return merge_traits(IsIsometricEmbeddedManifold(), IsDefaultMetric(EuclideanMetric()))
+end
+
+function allocation_promotion_function(::UnitaryMatrices{n,ℂ}, f, ::Tuple) where {n}
+    return complex
+end
+
+@doc raw"""
+    check_point(M, p; kwargs...)
+
+Check whether `p` is a valid point on the [`UnitaryMatrices`](@ref) `M`,
+i.e. that ``p`` has an determinante of absolute value one, i.e. that ``p^{\mathrm{H}}p``
+
+The tolerance for the last test can be set using the `kwargs...`.
+"""
+function check_point(M::UnitaryMatrices{n,𝔽}, p; kwargs...) where {n,𝔽}
+    if !isapprox(abs(det(p)), 1; kwargs...)
+        return DomainError(
+            det(p),
+            "The absolute value of the determinant of $p has to be 1 but it is $(abs(det(p)))",
+        )
+    end
+    if !isapprox(p' * p, one(p); kwargs...)
+        return DomainError(
+            norm(p' * p - one(p)),
+            "$p must be unitary but it's not at kwargs $kwargs",
+        )
+    end
+    return nothing
+end
+
+@doc raw"""
+    check_vector(M::UnitaryMatrices{n,𝔽}, p, X; kwargs... )
+
+Check whether `X` is a tangent vector to `p` on the [`UnitaryMatrices`](@ref)
+space `M`, i.e. after [`check_point`](@ref)`(M,p)`, `X` has to be skew symmetric (hermitian)
+dimension and orthogonal to `p`.
+
+The tolerance for the last test can be set using the `kwargs...`.
+"""
+function check_vector(M::UnitaryMatrices{n,𝔽}, p, X; kwargs...) where {n,𝔽}
+    return check_point(SkewHermitianMatrices(n, 𝔽), X; kwargs...)
+end
+
+@doc raw"""
+    embed(M::Unitary{n,𝔽}, p, X)
+
+Embed the tangent vector `X` at point `p` in `M` from
+its Lie algebra representation (set of skew matrices) into the
+Riemannian submanifold representation
+
+The formula reads
+```math
+X_{\text{embedded}} = p * X
+```
+"""
+embed(::UnitaryMatrices, p, X)
+
+function embed!(::UnitaryMatrices, Y, p, X)
+    return mul!(Y, p, X)
+end
+
+get_embedding(::UnitaryMatrices{n,𝔽}) where {n,𝔽} = Euclidean(n, n; field=𝔽)
+
+@doc raw"""
+     project(G::UnitaryMatrices{n,𝔽}, p)
+
+Project the point ``p ∈ 𝔽^{n × n}`` to the nearest point in
+``\mathrm{U}(n,𝔽)=``[`Unitary(n,𝔽)`](@ref) under the Frobenius norm.
+If ``p = U S V^\mathrm{H}`` is the singular value decomposition of ``p``, then the projection
+is
+
+````math
+  \operatorname{proj}_{\mathrm{U}(n,𝔽)} \colon p ↦ U V^\mathrm{H}.
+````
+"""
+project(::UnitaryMatrices, p)
+
+function project!(::UnitaryMatrices, q, p)
+    F = svd(p)
+    mul!(q, F.U, F.Vt)
+    return q
+end
+
+@doc raw"""
+     project(G::Unitary{n,𝔽}, p, X)
+
+Orthogonally project the tangent vector ``X ∈ 𝔽^{n × n}`` to the tangent space of
+[`UnitaryMatrices`](@ref)`(n,𝔽)` at ``p``,
+and change the representer to use the Lie algebra ``\mathfrak u(n, \mathbb F)``.
+The projection removes the Hermitian part of ``X``:
+```math
+  \operatorname{proj}_{p}(X) := \frac{1}{2}(X - X^\mathrm{H}).
+```
+"""
+project(::UnitaryMatrices, p, X)
+
+function project!(::UnitaryMatrices{n,𝔽}, Y, p, X) where {n,𝔽}
+    project!(SkewHermitianMatrices(n, 𝔽), Y, X)
+    return Y
+end


### PR DESCRIPTION
super seeds (and adapts) #345).

Besides adapting directlyy to the ManifoldsBase.jl 0.13 interface, this PR has one difference in that it distinguishes between unitary (orthogonal) matrices and the corresponding groups. Similarly to distinguishing Rotations and the Special Orthogonal group.

The rest will slowly be adapted here from the previous PR.