### PR TITLE
Follow up on manifold-specific allocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.16"
+version = "0.8.17"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -59,6 +59,22 @@ const PowerManifoldMultidimensional =
 
 Base.:^(M::AbstractManifold, n) = PowerManifold(M, n...)
 
+function allocate(::PowerManifoldNestedReplacing, x::AbstractArray{<:SArray})
+    return similar(x)
+end
+function allocate(
+    ::PowerManifoldNestedReplacing,
+    x::AbstractArray{<:ProductRepr{<:NTuple{N,SArray}}},
+) where {N}
+    return similar(x)
+end
+function allocate(
+    ::PowerManifoldNestedReplacing,
+    x::AbstractArray{<:ArrayPartition{T,<:NTuple{N,SArray}}},
+) where {T,N}
+    return similar(x)
+end
+
 for PowerRepr in [PowerManifoldNested, PowerManifoldNestedReplacing]
     @eval begin
         function allocate_result(::$PowerRepr, ::typeof(get_point), a)


### PR DESCRIPTION
Adds allocation methods for some nested replacing power manifold cases. Follow up on https://github.com/JuliaManifolds/ManifoldsBase.jl/pull/116 . Solves next part of #497 .