### PR TITLE
Update docstring to match implementation

### DIFF
--- a/src/manifolds/GeneralUnitaryMatrices.jl
+++ b/src/manifolds/GeneralUnitaryMatrices.jl
@@ -669,7 +669,7 @@ to the tangent space of `M` at `p`,
 and change the representer to use the corresponding Lie algebra, i.e. we compute
 
 ```math
-    \operatorname{proj}_p(X) = \frac{pX-(pX)^{\mathrm{T}}}{2},
+    \operatorname{proj}_p(X) = \frac{p^{\mathrm{H}} X - (p^{\mathrm{H}} X)^{\mathrm{H}}}{2},
 ```
 """
 project(::GeneralUnitaryMatrices, p, X)


### PR DESCRIPTION
Hi there, I found what I believe to be a small typo in the doc string of the `project!` method for general unitary matrices, as the implementation projects `p \ X` onto the skew-symmetric matrices, not `p * X`.