### PR TITLE
Introduce default methods on FR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.32"
+version = "0.8.33"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -288,6 +288,10 @@ function Base.copyto!(X::UMVTVector, Y::UMVTVector)
     return X
 end
 
+default_retraction_method(::FixedRankMatrices) = PolarRetraction()
+default_inverse_retraction_method(::FixedRankMatrices) = PolarInverseRetraction()
+default_vector_transport_method(::FixedRankMatrices) = ProjectionTransport()
+
 @doc raw"""
     embed(::FixedRankMatrices, p::SVDMPoint)
 

--- a/test/manifolds/fixed_rank.jl
+++ b/test/manifolds/fixed_rank.jl
@@ -56,6 +56,10 @@ include("../utils.jl")
         @test_throws DomainError is_point(M2, [1.0 0.0; 0.0 1.0; 0.0 0.0], true)
         @test Manifolds.check_point(M2, [1.0 0.0; 0.0 1.0; 0.0 0.0]) isa DomainError
 
+        @test default_retraction_method(M) === PolarRetraction()
+        @test default_inverse_retraction_method(M) === PolarInverseRetraction()
+        @test default_vector_transport_method(M) == ProjectionTransport()
+
         @test !is_vector(
             M,
             SVDMPoint([1.0 0.0; 0.0 1.0; 0.0 0.0]),


### PR DESCRIPTION
On fixed rank matrices, we do have a retraction, an inverse retraction and a vector transport. This PR introduces them as defaults.