### PR TITLE
Improvements to log for Stiefel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.35"
+version = "0.8.36"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/GrassmannStiefel.jl
+++ b/src/manifolds/GrassmannStiefel.jl
@@ -28,6 +28,7 @@ end
 ManifoldsBase.@manifold_element_forwards StiefelPoint value
 ManifoldsBase.@manifold_vector_forwards StiefelTVector value
 ManifoldsBase.@default_manifold_fallbacks Stiefel StiefelPoint StiefelTVector value value
+ManifoldsBase.@default_manifold_fallbacks (Stiefel{n,k,ℝ} where {n,k}) StiefelPoint StiefelTVector value value
 ManifoldsBase.@default_manifold_fallbacks Grassmann StiefelPoint StiefelTVector value value
 
 @doc raw"""

--- a/src/manifolds/StiefelCanonicalMetric.jl
+++ b/src/manifolds/StiefelCanonicalMetric.jl
@@ -163,17 +163,16 @@ function inverse_retract!(
     LV = allocate(V)
     Zcompl = qr(qfact.Z).Q[1:(2k), (k + 1):(2k)]
     @views begin
-        Vcorner = V[(k + 1):(2k), (k + 1):(2k)] #bottom right corner
         Vpcols = V[1:(2k), (k + 1):(2k)] #second half of the columns
         B = LV[(k + 1):(2k), 1:k]
         C = LV[(k + 1):(2k), (k + 1):(2k)]
         copyto!(V[1:(2k), 1:k], qfact.Z)
+        F = svd(Zcompl[(k + 1):(2k), 1:k]) # preprocessing: Procrustes
     end
-    F = svd(Vcorner) # preprocessing: Procrustes
-    S = allocate(B)
     new_Vpcols = allocate(Vpcols)
     mul!(new_Vpcols, Zcompl, F.U)
     mul!(Vpcols, new_Vpcols, F.V')
+    S = allocate(B)
     for _ in 1:(a.max_iterations)
         log_safe!(LV, V)
         norm(C) ≤ a.tolerance && break

--- a/src/manifolds/StiefelCanonicalMetric.jl
+++ b/src/manifolds/StiefelCanonicalMetric.jl
@@ -163,14 +163,17 @@ function inverse_retract!(
     LV = allocate(V)
     Zcompl = qr(qfact.Z).Q[1:(2k), (k + 1):(2k)]
     @views begin
-        Vpcols = V[1:(2k), (k + 1):(2 * k)] #second half of the columns
-        B = LV[(k + 1):(2 * k), 1:k]
-        C = LV[(k + 1):(2 * k), (k + 1):(2 * k)]
+        Vcorner = V[(k + 1):(2k), (k + 1):(2k)] #bottom right corner
+        Vpcols = V[1:(2k), (k + 1):(2k)] #second half of the columns
+        B = LV[(k + 1):(2k), 1:k]
+        C = LV[(k + 1):(2k), (k + 1):(2k)]
         copyto!(V[1:(2k), 1:k], qfact.Z)
-        copyto!(Vpcols, Zcompl)
     end
+    F = svd(Vcorner) # preprocessing: Procrustes
     S = allocate(B)
     new_Vpcols = allocate(Vpcols)
+    mul!(new_Vpcols, Zcompl, F.U)
+    mul!(Vpcols, new_Vpcols, F.V')
     for _ in 1:(a.max_iterations)
         log_safe!(LV, V)
         norm(C) ≤ a.tolerance && break

--- a/src/manifolds/StiefelEuclideanMetric.jl
+++ b/src/manifolds/StiefelEuclideanMetric.jl
@@ -126,6 +126,12 @@ function inverse_retract_project!(M::Stiefel, X, p, q)
     return X
 end
 
+function log!(M::Stiefel{n,k,ℝ}, X, p, q) where {n,k}
+    MM = MetricManifold(M, StiefelSubmersionMetric(-1 // 2))
+    log!(MM, X, p, q)
+    return X
+end
+
 @doc raw"""
     project(M::Stiefel,p)
 

--- a/src/manifolds/StiefelSubmersionMetric.jl
+++ b/src/manifolds/StiefelSubmersionMetric.jl
@@ -313,7 +313,6 @@ Compute the [`StiefelFactorization`](@ref) of ``x`` relative to the point ``p``.
 """
 function stiefel_factorization(p, x)
     n, k = size(p)
-    k ≤ div(n, 2) || throw(ArgumentError("k must be ≤ div(n, 2)"))
     T = Base.promote_eltype(p, x)
     U = allocate(p, T, Size(n, 2k))
     Z = allocate(p, T, Size(2k, k))

--- a/test/manifolds/stiefel.jl
+++ b/test/manifolds/stiefel.jl
@@ -98,7 +98,6 @@ include("../utils.jl")
             x = [1.0 0.0; 0.0 1.0; 0.0 0.0]
             y = exp(M, x, [0.0 0.0; 0.0 0.0; 1.0 1.0])
             z = exp(M, x, [0.0 0.0; 0.0 0.0; -1.0 1.0])
-            @test_throws MethodError distance(M, x, y)
             @test isapprox(
                 M,
                 retract(
@@ -123,7 +122,7 @@ include("../utils.jl")
                 pts,
                 basis_types_to_from=(DefaultOrthonormalBasis(),),
                 basis_types_vecs=(DefaultOrthonormalBasis(),),
-                test_exp_log=false,
+                test_exp_log=true,
                 default_inverse_retraction_method=PolarInverseRetraction(),
                 test_injectivity_radius=false,
                 test_is_tangent=true,
@@ -132,6 +131,7 @@ include("../utils.jl")
                 point_distributions=[Manifolds.uniform_distribution(M, pts[1])],
                 test_vee_hat=false,
                 projection_atol_multiplier=100.0,
+                exp_log_atol_multiplier=10.0,
                 retraction_atol_multiplier=10.0,
                 is_tangent_atol_multiplier=4 * 10.0^2,
                 retraction_methods=[


### PR DESCRIPTION
This PR makes several improvements to `log` implementations for Stiefel for various metrics, following up after #535:
- Add `log!` for `EuclideanMetric`, which just calls `log!` for `StiefelSubmersionMetric`. This approach is taken because the benchmark in the submersion metric paper (https://arxiv.org/abs/2103.12046) showed that this algorithm was fastest for the Euclidean metric.
- Speed up `log!` for `CanonicalMetric`. This is done by:
  - Replacing the view of the Q factor in the final line with an explicit slice. This drastically speeds up the function, since the view approach elementwise computes the entries of the Q factor, which is much slower than computing them all at once.
  - ~Removing the Procrustes pre-processing. I'm not certain what this does. It's absent from the formulation of the algorithm in Algorithm 4 of the above paper.~
  - Use a `lyap` solve in the inner loop. The paper gives a proof that shows that for short between `p` and `q`, `lyap` ("sylvester solve") outperforms the current approach, and for larger distances, the case is reversed. However, it's not clear how to choose between the two programmatically, and in the benchmarks (Table 1), the `lyap` approach converged faster for all cases considered. 
  - Use the `sylvester_factorization`. This probably doesn't speed up much; it just allows for more code reuse.