### PR TITLE
Using PythonPlot instead of PyPlot in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/src/misc/contributing.md
 benchmark/tune.json
 benchmark/results*
 docs/src/tutorials/*.md
+.CondaPkg

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.52"
+version = "0.8.53"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/Project.toml
+++ b/Project.toml
@@ -60,7 +60,7 @@ ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -68,4 +68,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["Test", "BoundaryValueDiffEq", "Colors", "DiffEqCallbacks", "DoubleFloats", "FiniteDifferences", "Gtk", "ImageIO", "ImageMagick", "OrdinaryDiffEq", "NLsolve", "Plots", "PyPlot", "Quaternions", "QuartzImageIO", "RecipesBase"]
+test = ["Test", "BoundaryValueDiffEq", "Colors", "DiffEqCallbacks", "DoubleFloats", "FiniteDifferences", "Gtk", "ImageIO", "ImageMagick", "OrdinaryDiffEq", "NLsolve", "Plots", "PythonPlot", "Quaternions", "QuartzImageIO", "RecipesBase"]

--- a/test/recipes.jl
+++ b/test/recipes.jl
@@ -101,8 +101,8 @@ include("utils.jl")
         #        end
         #        @plottest Hyp2_quiver joinpath(references_folder, "Hyp2Quiver.png") false
     end
-    @testset "3D Recipes in pyplot" begin
-        pyplot()
+    @testset "3D Recipes in pythonplot" begin
+        pythonplot()
         #        function Sphere2_plot()
         M = Sphere(2)
         pts = [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]]
@@ -128,7 +128,7 @@ include("utils.jl")
         #        @plottest Sphere2_plot_geo joinpath(references_folder, "Sphere2PlotGeo.png") false
 
         #        function Sphere2_quiver()
-        pyplot()
+        pythonplot()
         M = Sphere(2)
         pts2 = [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]]
         p3 = 1 / sqrt(3) .* [1.0, -1.0, 1.0]


### PR DESCRIPTION
Plots.jl has deprecated its PyPlot backend in favor of PythonPlot. This PR switches to using PythonPlot in our tests.