### PR TITLE
Fix defaults on Grassmann

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.56"
+version = "0.8.57"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -219,6 +219,25 @@ for
 """
 convert(::Type{ProjectorPoint}, p::StiefelPoint) = ProjectorPoint(p.value * p.value')
 
+"""
+    default_retraction_method(M::Grassmann, ::Type{ProjectorPoint})
+
+Return `ExponentialRetraction` as the default on the [`Grassmann`](@ref) manifold
+with projection matrices
+"""
 default_retraction_method(::Grassmann, ::Type{ProjectorPoint}) = ExponentialRetraction()
+"""
+    default_retraction_method(M::Grassmann)
+    default_retraction_method(M::Grassmann, ::Type{StiefelPoint})
+
+Return `PolarRetracion` as the default on the [`Grassmann`](@ref) manifold
+with projection matrices
+"""
 default_retraction_method(::Grassmann) = PolarRetraction()
+"""
+    default_vector_transport_method(M::Grassmann)
+
+Return the `ProjectionTransport` as the default vector transport method
+for the [`Grassmann`](@ref) manifold.
+"""
 default_vector_transport_method(::Grassmann) = ProjectionTransport()

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -218,3 +218,7 @@ for
 ```
 """
 convert(::Type{ProjectorPoint}, p::StiefelPoint) = ProjectorPoint(p.value * p.value')
+
+default_retraction_method(::Grassmann, ::Type{ProjectorPoint}) = ExponentialRetraction()
+default_retraction_method(::Grassmann) = PolarRetraction()
+default_vector_transport_method(::Grassmann) = ProjectionTransport()

--- a/test/manifolds/grassmann.jl
+++ b/test/manifolds/grassmann.jl
@@ -9,6 +9,11 @@ include("../utils.jl")
             @test manifold_dimension(M) == 2
             @test !is_flat(M)
             @test is_flat(Grassmann(2, 1))
+            @test default_retraction_method(M) == PolarRetraction()
+            @test default_retraction_method(M, typeof(zeros(3, 2))) == PolarRetraction()
+            @test default_retraction_method(M, ProjectorPoint) == ExponentialRetraction()
+            @test default_retraction_method(M) == PolarRetraction()
+            @test default_vector_transport_method(M) == ProjectionTransport()
             @test get_total_space(M) == Stiefel(3, 2, ℝ)
             @test get_orbit_action(M) ==
                   Manifolds.RowwiseMultiplicationAction(M, Orthogonal(2))


### PR DESCRIPTION
Main reason – it defaulted to exp/parallel transport, which do not exist in Stiefel representation.