### PR TITLE
Bump allowed ambiguities

### DIFF
--- a/test/ambiguities.jl
+++ b/test/ambiguities.jl
@@ -4,7 +4,7 @@
         # Interims solution until we follow what was proposed in
         # https://discourse.julialang.org/t/avoid-ambiguities-with-individual-number-element-identity/62465/2
         fmbs = filter(x -> !any(has_type_in_signature.(x, Identity)), mbs)
-        FMBS_LIMIT = 23
+        FMBS_LIMIT = 34
         println("Number of ManifoldsBase.jl ambiguities: $(length(fmbs))")
         @test length(fmbs) <= FMBS_LIMIT
         if length(fmbs) > FMBS_LIMIT


### PR DESCRIPTION
It looks like https://github.com/JuliaManifolds/ManifoldsBase.jl/pull/155 caused some new harmless ambiguities in the `convert` function. This PR bumps how many are allowed.