### PR TITLE
Extend and fix `rand`.

### DIFF
--- a/src/manifolds/Euclidean.jl
+++ b/src/manifolds/Euclidean.jl
@@ -572,7 +572,7 @@ project(::Euclidean{Tuple{}}, ::Number, X::Number) = X
 project!(::Euclidean, Y, p, X) = copyto!(Y, X)
 
 function Random.rand!(::Euclidean, pX; σ=one(eltype(pX)), vector_at=nothing)
-    pX .= randn(size(pX)) .* σ
+    pX .= randn(eltype(pX), size(pX)) .* σ
     return pX
 end
 function Random.rand!(
@@ -582,7 +582,7 @@ function Random.rand!(
     σ=one(eltype(pX)),
     vector_at=nothing,
 )
-    pX .= randn(rng, size(pX)) .* σ
+    pX .= randn(rng, eltype(pX), size(pX)) .* σ
     return pX
 end
 

--- a/src/manifolds/GeneralizedGrassmann.jl
+++ b/src/manifolds/GeneralizedGrassmann.jl
@@ -315,6 +315,18 @@ function project!(M::GeneralizedGrassmann, Y, p, X)
     return Y
 end
 
+
+function Random.rand!(M::GeneralizedGrassmann, pX; kwargs...)
+    return Random.rand!(Random.default_rng(), M, pX; kwargs...)
+end
+function Random.rand!(
+    rng::AbstractRNG,
+    M::GeneralizedGrassmann,
+    pX; kwargs...
+)
+    rand!(rng, get_embedding(M), pX, kwargs...)
+end
+
 @doc raw"""
     representation_size(M::GeneralizedGrassmann{n,k})
 

--- a/src/manifolds/GeneralizedGrassmann.jl
+++ b/src/manifolds/GeneralizedGrassmann.jl
@@ -315,16 +315,39 @@ function project!(M::GeneralizedGrassmann, Y, p, X)
     return Y
 end
 
+@doc raw"""
+    rand(::GeneralizedGrassmann; vector_at=nothing, σ::Real=1.0)
 
-function Random.rand!(M::GeneralizedGrassmann, pX; kwargs...)
+When `vector_at` is `nothing`, return a random (Gaussian) point `p` on the [`GeneralizedGrassmann`](@ref)
+manifold `M` by generating a (Gaussian) matrix with standard deviation `σ` and return the
+(generalized) orthogonalized version, i.e. return the projection onto the manifold of the
+Q component of the QR decomposition of the random matrix of size ``n×k``.
+
+When `vector_at` is not `nothing`, return a (Gaussian) random vector from the tangent space
+``T_{vector\_at}\mathrm{St}(n,k)`` with mean zero and standard deviation `σ` by projecting a
+random Matrix onto the tangent vector at `vector_at`.
+"""
+rand(::GeneralizedGrassmann; σ::Real=1.0)
+
+function Random.rand!(M::GeneralizedGrassmann{n,k,ℝ}, pX; kwargs...) where {n,k}
     return Random.rand!(Random.default_rng(), M, pX; kwargs...)
 end
 function Random.rand!(
     rng::AbstractRNG,
-    M::GeneralizedGrassmann,
-    pX; kwargs...
-)
-    rand!(rng, get_embedding(M), pX, kwargs...)
+    M::GeneralizedGrassmann{n,k,ℝ},
+    pX;
+    vector_at=nothing,
+    σ::Real=one(real(eltype(pX))),
+) where {n,k}
+    if vector_at === nothing
+        A = σ * randn(rng, eltype(pX), n, k)
+        project!(M, pX, Matrix(qr(A).Q))
+    else
+        Z = σ * randn(rng, eltype(pX), size(pX))
+        project!(M, pX, vector_at, Z)
+        normalize!(pX)
+    end
+    return pX
 end
 
 @doc raw"""

--- a/src/manifolds/GeneralizedStiefel.jl
+++ b/src/manifolds/GeneralizedStiefel.jl
@@ -177,6 +177,43 @@ function project!(M::GeneralizedStiefel, Y, p, X)
     mul!(Y, p, Hermitian((A .+ A') ./ 2), -1, 1)
     return Y
 end
+
+
+@doc raw"""
+    rand(::GeneralizedStiefel; vector_at=nothing, σ::Real=1.0)
+
+When `vector_at` is `nothing`, return a random (Gaussian) point `x` on the [`GeneralizedStiefel`](@ref)
+manifold `M` by generating a (Gaussian) matrix with standard deviation `σ` and return the
+(generalized) orthogonalized version, i.e. return the projection onto the manifold of the
+Q component of the QR decomposition of the random matrix of size ``n×k``.
+
+When `vector_at` is not `nothing`, return a (Gaussian) random vector from the tangent space
+``T_{vector\_at}\mathrm{St}(n,k)`` with mean zero and standard deviation `σ` by projecting a
+random Matrix onto the tangent vector at `vector_at`.
+"""
+rand(::GeneralizedStiefel; σ::Real=1.0)
+
+function Random.rand!(M::GeneralizedStiefel, pX; kwargs...)
+    return Random.rand!(Random.default_rng(), M, pX; kwargs...)
+end
+function Random.rand!(
+    rng::AbstractRNG,
+    M::GeneralizedStiefel{n,k,𝔽},
+    pX;
+    vector_at=nothing,
+    σ::Real=one(real(eltype(pX))),
+) where {n,k,𝔽}
+    if vector_at === nothing
+        A = σ * randn(rng, 𝔽 === ℝ ? Float64 : ComplexF64, n, k)
+        project!(M, pX, Matrix(qr(A).Q))
+    else
+        Z = σ * randn(rng, eltype(pX), size(pX))
+        project!(M, pX, vector_at, Z)
+        normalize!(pX)
+    end
+    return pX
+end
+
 @doc raw"""
     retract(M::GeneralizedStiefel, p, X)
     retract(M::GeneralizedStiefel, p, X, ::PolarRetraction)

--- a/src/manifolds/GeneralizedStiefel.jl
+++ b/src/manifolds/GeneralizedStiefel.jl
@@ -178,11 +178,10 @@ function project!(M::GeneralizedStiefel, Y, p, X)
     return Y
 end
 
-
 @doc raw"""
     rand(::GeneralizedStiefel; vector_at=nothing, σ::Real=1.0)
 
-When `vector_at` is `nothing`, return a random (Gaussian) point `x` on the [`GeneralizedStiefel`](@ref)
+When `vector_at` is `nothing`, return a random (Gaussian) point `p` on the [`GeneralizedStiefel`](@ref)
 manifold `M` by generating a (Gaussian) matrix with standard deviation `σ` and return the
 (generalized) orthogonalized version, i.e. return the projection onto the manifold of the
 Q component of the QR decomposition of the random matrix of size ``n×k``.
@@ -193,18 +192,18 @@ random Matrix onto the tangent vector at `vector_at`.
 """
 rand(::GeneralizedStiefel; σ::Real=1.0)
 
-function Random.rand!(M::GeneralizedStiefel, pX; kwargs...)
+function Random.rand!(M::GeneralizedStiefel{n,k,ℝ}, pX; kwargs...) where {n,k}
     return Random.rand!(Random.default_rng(), M, pX; kwargs...)
 end
 function Random.rand!(
     rng::AbstractRNG,
-    M::GeneralizedStiefel{n,k,𝔽},
+    M::GeneralizedStiefel{n,k,ℝ},
     pX;
     vector_at=nothing,
     σ::Real=one(real(eltype(pX))),
-) where {n,k,𝔽}
+) where {n,k}
     if vector_at === nothing
-        A = σ * randn(rng, 𝔽 === ℝ ? Float64 : ComplexF64, n, k)
+        A = σ * randn(rng, eltype(pX), n, k)
         project!(M, pX, Matrix(qr(A).Q))
     else
         Z = σ * randn(rng, eltype(pX), size(pX))

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -408,9 +408,9 @@ project!(::AbstractSphere, Y, p, X) = (Y .= X .- real(dot(p, X)) .* p)
 
 function Random.rand!(M::AbstractSphere, pX; vector_at=nothing, σ=one(eltype(pX)))
     if vector_at === nothing
-        project!(M, pX, randn(representation_size(M)))
+        project!(M, pX, randn(eltype(pX), representation_size(M)))
     else
-        n = σ * randn(size(pX)) # Gaussian in embedding
+        n = σ * randn(eltype(pX), size(pX)) # Gaussian in embedding
         project!(M, pX, vector_at, n) #project to TpM (keeps Gaussianness)
     end
     return pX
@@ -423,9 +423,9 @@ function Random.rand!(
     σ=one(eltype(pX)),
 )
     if vector_at === nothing
-        project!(M, pX, randn(rng, representation_size(M)))
+        project!(M, pX, randn(rng, eltype(pX), representation_size(M)))
     else
-        n = σ * randn(rng, size(pX)) # Gaussian in embedding
+        n = σ * randn(rng, eltype(pX), size(pX)) # Gaussian in embedding
         project!(M, pX, vector_at, n) #project to TpM (keeps Gaussianness)
     end
     return pX

--- a/src/manifolds/Tucker.jl
+++ b/src/manifolds/Tucker.jl
@@ -482,7 +482,7 @@ function get_basis(
     r⃗ = size(𝔄.hosvd.core)
 
     U = 𝔄.hosvd.U
-    U⊥ = ntuple(d -> Matrix(qr(I - U[d] * U[d]', Val(true)).Q)[:, 1:(n⃗[d] - r⃗[d])], D)
+    U⊥ = ntuple(d -> Matrix(qr(I - U[d] * U[d]', ColumnNorm()).Q)[:, 1:(n⃗[d] - r⃗[d])], D)
 
     basis = HOSVDBasis(𝔄, U⊥)
     return CachedBasis(basisType, basis)

--- a/test/manifolds/euclidean.jl
+++ b/test/manifolds/euclidean.jl
@@ -297,8 +297,12 @@ using Manifolds: induced_basis
         @test DDB.vs isa ManifoldsBase.TangentSpaceType
     end
     @testset "RNG point with σ" begin
+        Random.seed!(42)
         @test is_point(E, rand(E; σ=10.0))
         @test is_point(E, rand(MersenneTwister(123), E; σ=10.0))
+        pc = rand(Ec)
+        @test is_point(Ec, pc)
+        @test norm(imag.(pc)) != 0
     end
 
     @testset "StaticArrays specializations" begin

--- a/test/manifolds/generalized_grassmann.jl
+++ b/test/manifolds/generalized_grassmann.jl
@@ -35,6 +35,9 @@ include("../utils.jl")
             @test injectivity_radius(M, p) == π / 2
             @test injectivity_radius(M, p, ExponentialRetraction()) == π / 2
             @test mean(M, [p, p, p]) == p
+            Random.seed!(42)
+            @test is_point(M, rand(M))
+            @test is_vector(M, p, rand(M; vector_at=p))
         end
         @testset "Embedding and Projection" begin
             q = similar(p)

--- a/test/manifolds/generalized_stiefel.jl
+++ b/test/manifolds/generalized_stiefel.jl
@@ -31,6 +31,8 @@ include("../utils.jl")
             )
             @test_throws DomainError is_vector(M, p, X, true)
             @test default_retraction_method(M) == ProjectionRetraction()
+            @test is_point(M, rand(M))
+            @test is_vector(M, p, rand(M; vector_at=p))
         end
         @testset "Embedding and Projection" begin
             @test get_embedding(GeneralizedStiefel(3, 2)) == Euclidean(3, 2)

--- a/test/manifolds/sphere.jl
+++ b/test/manifolds/sphere.jl
@@ -147,6 +147,10 @@ using ManifoldsBase: TFVector
         Y = [2.0, 1.0im, 20.0]
         X = project(M, q, Y)
         @test is_vector(M, q, X, true; atol=10^(-14))
+        Random.seed!(42)
+        r = rand(M)
+        @test is_point(M, r)
+        @test norm(imag.(r)) != 0
     end
 
     @testset "Quaternion Sphere" begin


### PR DESCRIPTION
This PR

* fixes complex sphere random points (resolves #601)
* fixes complex Euclidean random points
* introduces (real) Generalised Grassmann points/vectors
* introduces (real) Generalised Stiefel points/vectors

It seems on `M=Sphere(2, ℍ)` the result is still real and not Quaternion for `rand(M)`, but I could not yet find the culprit in the allocation labyrinth when allocating the solution `p` (before calling `rand!(M, p)`). The following actually works fine

```Julia
b =  [ Quaternions.quat(1.0), Quaternions.quat(1.0), Quaternions.quat(1.0)];
Manifolds.rand!(M,b)
is_point(M,b)
```
yields true and `b` has nonzero entries in all 4 quaternion entries in each quaternion. SO this is really just an allocation problem for quaternion problems.