### PR TITLE
Fix #613

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.64"
+version = "0.8.65"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/groups/group.jl
+++ b/src/groups/group.jl
@@ -346,8 +346,9 @@ function is_vector(
     kwargs...,
 )
     if cbp
-        ie = is_point(G, e; kwargs...)
-        (!te) && return ie
+        # pass te down so this throws an error if te=true
+        # if !te and is_point was false -> return false, otherwise continue
+        (!te && !is_point(G, e, te; kwargs...)) && return false
     end
     return is_vector(next_trait(t), G, identity_element(G), X, te, false; kwargs...)
 end

--- a/test/groups/special_orthogonal.jl
+++ b/test/groups/special_orthogonal.jl
@@ -62,12 +62,10 @@ include("group_utils.jl")
                 @test isapprox(p, exp_lie(G, log_lie(G, p)))
             end
         end
-
         @testset "Decorator forwards to group" begin
             DM = NotImplementedGroupDecorator(G)
             test_group(DM, pts, Xpts, Xpts; test_diff=true)
         end
-
         @testset "Group forwards to decorated" begin
             retraction_methods = [
                 Manifolds.PolarRetraction(),
@@ -134,7 +132,6 @@ include("group_utils.jl")
             project!(G, z2, z)
             @test isapprox(M, z2, project(M, z))
         end
-
         @testset "vee/hat" begin
             X = Xpts[1]
             pe = Identity(G)
@@ -177,6 +174,11 @@ include("group_utils.jl")
             @test isone(q)
             e2 = Identity(G)
             @test mul!(e2, e, e) === e2
+        end
+        @testset "Identity and point/vector check" begin
+            # see https://github.com/JuliaManifolds/Manifolds.jl/issues/613
+            @test !is_vector(G, gI, ones(n, n)) #not skew
+            @test !is_vector(G, gI, ones(n)) # wrong size
         end
     end
 end


### PR DESCRIPTION
This resolves #613 

The problem was that if `is_point` returned true and `te` was false, the `is_vector` already returned true without checking the vector.

Now it correctly
1. Throws an error if the point check fails and `te=true` (not done before)
2. returns false if the point check fails and `te=false`
3. continues to checking the vector (as opposed to before) if the point check passes.