### PR TITLE
Reduce TTFisapprox on ProductGroup

### DIFF
--- a/src/groups/product_group.jl
+++ b/src/groups/product_group.jl
@@ -353,3 +353,20 @@ Base.@propagate_inbounds function Base.setindex!(
 )
     return setindex!(q, p, base_manifold(M), i)
 end
+
+# these isapprox methods are here just to reduce time-to-first-isapprox
+function isapprox(G::ProductGroup, p::ArrayPartition, q::ArrayPartition; kwargs...)
+    return isapprox(G.manifold, p, q; kwargs...)
+end
+function isapprox(
+    G::ProductGroup,
+    p::ArrayPartition,
+    X::ArrayPartition,
+    Y::ArrayPartition;
+    kwargs...,
+)
+    return isapprox(G.manifold, p, X, Y; kwargs...)
+end
+function isapprox(G::ProductGroup, ::Identity{ProductOperation}, X, Y; kwargs...)
+    return isapprox(G.manifold, identity_element(G), X, Y; kwargs...)
+end


### PR DESCRIPTION
An issue I've noticed when working on #609 . The last `isapprox` (for `ProductGroup`) originally took like half a minute to compile for me, with this it's a few seconds. Still too much but at least it's a bit better.