### PR TITLE
Add more functions on ProbabilitySimplex

### DIFF
--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -949,4 +949,14 @@ export get_basis,
 # atlases and charts
 export get_point, get_point!, get_parameters, get_parameters!
 
+# additional functions on Simplex
+export from_probability_amplitude,
+    from_probability_amplitude!,
+    from_probability_amplitude_diff,
+    from_probability_amplitude_diff!,
+    to_probability_amplitude,
+    to_probability_amplitude!,
+    to_probability_amplitude_diff,
+    to_probability_amplitude_diff!
+
 end # module

--- a/src/manifolds/ProbabilitySimplex.jl
+++ b/src/manifolds/ProbabilitySimplex.jl
@@ -211,7 +211,6 @@ function get_coordinates_orthonormal!(
         to_probability_amplitude_diff(M, p, X),
         R,
     )
-    Xc .*= 2
     return Xc
 end
 
@@ -222,8 +221,7 @@ function get_vector_orthonormal!(
     Xc,
     R::RealNumbers,
 ) where {N}
-    Xcs = Xc / 2
-    X = get_vector_orthonormal(Sphere(N), to_probability_amplitude(M, p), Xcs, R)
+    X = get_vector_orthonormal(Sphere(N), to_probability_amplitude(M, p), Xc, R)
     return from_probability_amplitude_diff!(M, Y, to_probability_amplitude(M, p), X)
 end
 
@@ -508,7 +506,7 @@ function to_probability_amplitude_diff(M::ProbabilitySimplex, p, X)
 end
 
 function to_probability_amplitude_diff!(::ProbabilitySimplex, Y, p, X)
-    Y .= X ./ sqrt.(p) ./ 2
+    Y .= X ./ sqrt.(p)
     return Y
 end
 
@@ -516,13 +514,13 @@ end
     from_probability_amplitude_diff(M::ProbabilitySimplex, p, X)
 
 Compute differential of [`from_probability_amplitude`](@ref) at tangent vector `X` from the
-tangent space at `p` from a sphere with a scaled metric.
+tangent space at `p` from a sphere.
 """
 function from_probability_amplitude_diff(M::ProbabilitySimplex, p, X)
     return from_probability_amplitude_diff!(M, similar(X), p, X)
 end
 
 function from_probability_amplitude_diff!(::ProbabilitySimplex, Y, p, X)
-    Y .= 2 .* p .* X
+    Y .= p .* X
     return Y
 end

--- a/test/manifolds/probability_simplex.jl
+++ b/test/manifolds/probability_simplex.jl
@@ -7,6 +7,7 @@ include("../utils.jl")
     q = [0.3, 0.6, 0.1]
     X = zeros(3)
     Y = [-0.1, 0.05, 0.05]
+    @test repr(M) == "ProbabilitySimplex(2; boundary=:open)"
     @test is_point(M, p)
     @test_throws DomainError is_point(M, p .+ 1, true)
     @test_throws ManifoldDomainError is_point(M, [0], true)
@@ -49,6 +50,7 @@ include("../utils.jl")
             test_manifold(
                 M,
                 pts,
+                basis_types_to_from=(DefaultOrthonormalBasis(),),
                 test_injectivity_radius=false,
                 test_project_tangent=true,
                 test_musical_isomorphisms=true,
@@ -110,5 +112,19 @@ include("../utils.jl")
         @test inner(Mb, p, X, Y) == 8
 
         @test_throws ArgumentError ProbabilitySimplex(2; boundary=:tomato)
+    end
+
+    @testset "Probability amplitudes" begin
+        p = [0.1, 0.7, 0.2]
+        Y = [-0.1, 0.05, 0.05]
+        @test to_probability_amplitude(M, p) ≈
+              [0.31622776601683794, 0.8366600265340756, 0.4472135954999579]
+        @test from_probability_amplitude(
+            M,
+            [0.31622776601683794, 0.8366600265340756, 0.4472135954999579],
+        ) ≈ p
+        @test to_probability_amplitude_diff(M, p, Y) ≈
+              [-0.15811388300841897, 0.02988071523335984, 0.05590169943749475]
+        @test from_probability_amplitude_diff(M, p, Y) ≈ [-0.02, 0.07, 0.02]
     end
 end

--- a/test/manifolds/probability_simplex.jl
+++ b/test/manifolds/probability_simplex.jl
@@ -124,7 +124,7 @@ include("../utils.jl")
             [0.31622776601683794, 0.8366600265340756, 0.4472135954999579],
         ) ≈ p
         @test to_probability_amplitude_diff(M, p, Y) ≈
-              [-0.15811388300841897, 0.02988071523335984, 0.05590169943749475]
-        @test from_probability_amplitude_diff(M, p, Y) ≈ [-0.02, 0.07, 0.02]
+              [-0.31622776601683794, 0.05976143046671968, 0.1118033988749895]
+        @test from_probability_amplitude_diff(M, p, Y) ≈ [-0.01, 0.035, 0.01]
     end
 end


### PR DESCRIPTION
I've implemented the isomorphism between interior of probability simplex and a scaled sphere, which in turn are used to define an orthonormal basis on the probability simplex. This is essentially what is described in https://github.com/JuliaManifolds/Manifolds.jl/issues/606#issuecomment-1546866436 but with a different scaling. Let me know if this scaling feels right.