### PR TITLE
Add injectivity radius on fixed rank matrices

### DIFF
--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -352,6 +352,21 @@ end
 
 get_embedding(::FixedRankMatrices{m,n,k,𝔽}) where {m,n,k,𝔽} = Euclidean(m, n; field=𝔽)
 
+"""
+    injectivity_radius(::FixedRankMatrices)
+
+Return the incjectivity radius of the manifold of [`FixedRankMatrices`](@ref), i.e. 0.
+See [^HosseiniUschmajew2017].
+
+[^HosseiniUschmajew2017]:
+    > S. Hosseini and A. Uschmajew, “A Riemannian Gradient Sampling Algorithm for Nonsmooth
+    > Optimization on Manifolds,” SIAM J. Optim., vol. 27, no. 1, pp. 173–189, Jan. 2017,
+    > doi: [10.1137/16M1069298](https://doi.org/10.1137/16M1069298).
+"""
+function injectivity_radius(::FixedRankMatrices{m,n,k}) where {m,n,k}
+    return 0.0
+end
+
 @doc raw"""
     inner(M::FixedRankMatrices, p::SVDMPoint, X::UMVTVector, Y::UMVTVector)
 

--- a/test/manifolds/fixed_rank.jl
+++ b/test/manifolds/fixed_rank.jl
@@ -87,6 +87,8 @@ include("../utils.jl")
         q2 = similar(q)
         embed!(M, q2, p)
         @test q == q2
+
+        @test injectivity_radius(M2) == 0.0
     end
     types = [[Matrix{Float64}, Vector{Float64}, Matrix{Float64}]]
     TEST_FLOAT32 && push!(types, [Matrix{Float32}, Vector{Float32}, Matrix{Float32}])


### PR DESCRIPTION
I've found a note that says it is 0. I'm going to make a PR to Manopt later that makes `max_stepsize` return 1 when injectivity radius is 0 to make algorithms usable with this addition.