### PR TITLE
Add more SE2 and SE3 performance dispatches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.80"
+version = "0.8.81"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -173,7 +173,7 @@ end
 # We need to prevent decorator unwrapping so that the correct `get_vector!` gets called
 # and applies proper padding to the result if `X` happens to be a matrix.
 # Otherwise rare random bugs happen where the padding is not applied.
-function get_vector(G::SemidirectProductGroup, p, X, B::AbstractOrthogonalBasis)
+function get_vector(G::SemidirectProductGroup, p, X, B::VeeOrthogonalBasis)
     Y = allocate_result(G, get_vector, p, X)
     return get_vector!(G, Y, p, X, B)
 end

--- a/src/groups/semidirect_product_group.jl
+++ b/src/groups/semidirect_product_group.jl
@@ -173,7 +173,7 @@ end
 # We need to prevent decorator unwrapping so that the correct `get_vector!` gets called
 # and applies proper padding to the result if `X` happens to be a matrix.
 # Otherwise rare random bugs happen where the padding is not applied.
-function get_vector(G::SemidirectProductGroup, p, X, B::VeeOrthogonalBasis)
+function get_vector(G::SemidirectProductGroup, p, X, B::AbstractOrthogonalBasis)
     Y = allocate_result(G, get_vector, p, X)
     return get_vector!(G, Y, p, X, B)
 end

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -748,7 +748,7 @@ function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
         get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(3)], ℝ),
-        get_vector_orthogonal(M2.manifold, p.x[2], c[SA[4,5,6]], ℝ),
+        get_vector_orthogonal(M2.manifold, p.x[2], c[SA[4, 5, 6]], ℝ),
     )
 end
 function get_vector(
@@ -759,7 +759,7 @@ function get_vector(
 )
     return ArrayPartition(
         get_vector(M.manifold.manifolds[1].manifold, p.x[1], c[SOneTo(3)], basis),
-        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[SA[4,5,6]], basis),
+        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[SA[4, 5, 6]], basis),
     )
 end
 function compose(::SpecialEuclidean, p::ArrayPartition, q::ArrayPartition)

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -717,7 +717,7 @@ function get_coordinates(
     M::SpecialEuclidean,
     p::ArrayPartition,
     X::ArrayPartition,
-    basis::AbstractBasis,
+    basis::DefaultOrthogonalBasis,
 )
     M1, M2 = M.manifold.manifolds
     return vcat(
@@ -736,7 +736,7 @@ function get_vector(
     M::SpecialEuclidean{2},
     p::ArrayPartition,
     c::AbstractVector,
-    basis::AbstractOrthogonalBasis,
+    basis::DefaultOrthogonalBasis,
 )
     return ArrayPartition(
         get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(c, 1:2), basis),
@@ -754,7 +754,7 @@ function get_vector(
     M::SpecialEuclidean{3},
     p::ArrayPartition,
     Xc::AbstractVector,
-    basis::AbstractOrthogonalBasis,
+    basis::DefaultOrthogonalBasis,
 )
     return ArrayPartition(
         get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(Xc, 1:3), basis),

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -725,7 +725,7 @@ function get_coordinates(
         get_coordinates(M2.manifold, p.x[2], X.x[2], basis),
     )
 end
-function hat(M::SpecialEuclidean{2}, p::ArrayPartition, c)
+function hat(M::SpecialEuclidean{2}, p::ArrayPartition, c::AbstractVector)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
         get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(2)], ℝ),
@@ -744,7 +744,7 @@ function get_vector(
     )
 end
 
-function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c)
+function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c::AbstractVector)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
         get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(3)], ℝ),

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -739,26 +739,27 @@ function get_vector(
     basis::DefaultOrthogonalBasis,
 )
     return ArrayPartition(
-        get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(c, 1:2), basis),
-        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[3], basis),
+        get_vector(M.manifold.manifolds[1].manifold, p.x[1], c[SOneTo(2)], basis),
+        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[SA[3]], basis),
     )
 end
+
 function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
-        get_vector_orthogonal(M1.manifold, p.x[1], view(c, 1:3), ℝ),
-        get_vector_orthogonal(M2.manifold, p.x[2], view(c, 4:6), ℝ),
+        get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(3)], ℝ),
+        get_vector_orthogonal(M2.manifold, p.x[2], c[SA[4,5,6]], ℝ),
     )
 end
 function get_vector(
     M::SpecialEuclidean{3},
     p::ArrayPartition,
-    Xc::AbstractVector,
+    c::AbstractVector,
     basis::DefaultOrthogonalBasis,
 )
     return ArrayPartition(
-        get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(Xc, 1:3), basis),
-        get_vector(M.manifold.manifolds[2].manifold, p.x[2], view(Xc, 4:6), basis),
+        get_vector(M.manifold.manifolds[1].manifold, p.x[1], c[SOneTo(3)], basis),
+        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[SA[4,5,6]], basis),
     )
 end
 function compose(::SpecialEuclidean, p::ArrayPartition, q::ArrayPartition)

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -713,18 +713,52 @@ function vee(M::SpecialEuclidean, p::ArrayPartition, X::ArrayPartition)
     M1, M2 = M.manifold.manifolds
     return vcat(vee(M1.manifold, p.x[1], X.x[1]), vee(M2.manifold, p.x[2], X.x[2]))
 end
-function hat(M::SpecialEuclidean{2}, p::ArrayPartition, c::SVector)
+function get_coordinates(
+    M::SpecialEuclidean,
+    p::ArrayPartition,
+    X::ArrayPartition,
+    basis::AbstractBasis,
+)
+    M1, M2 = M.manifold.manifolds
+    return vcat(
+        get_coordinates(M1.manifold, p.x[1], X.x[1], basis),
+        get_coordinates(M2.manifold, p.x[2], X.x[2], basis),
+    )
+end
+function hat(M::SpecialEuclidean{2}, p::ArrayPartition, c)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
         get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(2)], ℝ),
         get_vector_orthogonal(M2.manifold, p.x[2], c[SA[3]], ℝ),
     )
 end
-function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c::SVector)
+function get_vector(
+    M::SpecialEuclidean{2},
+    p::ArrayPartition,
+    c::AbstractVector,
+    basis::AbstractOrthogonalBasis,
+)
+    return ArrayPartition(
+        get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(c, 1:2), basis),
+        get_vector(M.manifold.manifolds[2].manifold, p.x[2], c[3], basis),
+    )
+end
+function hat(M::SpecialEuclidean{3}, p::ArrayPartition, c)
     M1, M2 = M.manifold.manifolds
     return ArrayPartition(
-        get_vector_orthogonal(M1.manifold, p.x[1], c[SOneTo(3)], ℝ),
-        get_vector_orthogonal(M2.manifold, p.x[2], c[SA[4, 5, 6]], ℝ),
+        get_vector_orthogonal(M1.manifold, p.x[1], view(c, 1:3), ℝ),
+        get_vector_orthogonal(M2.manifold, p.x[2], view(c, 4:6), ℝ),
+    )
+end
+function get_vector(
+    M::SpecialEuclidean{3},
+    p::ArrayPartition,
+    Xc::AbstractVector,
+    basis::AbstractOrthogonalBasis,
+)
+    return ArrayPartition(
+        get_vector(M.manifold.manifolds[1].manifold, p.x[1], view(Xc, 1:3), basis),
+        get_vector(M.manifold.manifolds[2].manifold, p.x[2], view(Xc, 4:6), basis),
     )
 end
 function compose(::SpecialEuclidean, p::ArrayPartition, q::ArrayPartition)

--- a/test/groups/special_euclidean.jl
+++ b/test/groups/special_euclidean.jl
@@ -382,15 +382,29 @@ Random.seed!(10)
             @test isapprox(SEn, log(SEn, pts[1], pts[1]), 0 .* Xs[1]; atol=1e-16)
             @test isapprox(SEn, exp(SEn, pts[1], 0 .* Xs[1]), pts[1])
             vee(SEn, pts[1], Xs[2])
+            get_coordinates(SEn, pts[1], Xs[2], DefaultOrthogonalBasis())
             csen = n == 2 ? SA[1.0, 2.0, 3.0] : SA[1.0, 0.0, 2.0, 2.0, -1.0, 1.0]
             hat(SEn, pts[1], csen)
+            get_vector(SEn, pts[1], csen, DefaultOrthogonalBasis())
             # @btime shows 0 but `@allocations` is inaccurate
             @static if VERSION >= v"1.9-DEV"
                 @test (@allocations exp(SEn, pts[1], Xs[1])) <= 4
                 @test (@allocations compose(SEn, pts[1], pts[2])) <= 4
                 @test (@allocations log(SEn, pts[1], pts[2])) <= 28
                 @test (@allocations vee(SEn, pts[1], Xs[2])) <= 13
+                @test (@allocations get_coordinates(
+                    SEn,
+                    pts[1],
+                    Xs[2],
+                    DefaultOrthogonalBasis(),
+                )) <= 13
                 @test (@allocations hat(SEn, pts[1], csen)) <= 13
+                @test (@allocations get_vector(
+                    SEn,
+                    pts[1],
+                    csen,
+                    DefaultOrthogonalBasis(),
+                )) <= 13
             end
         end
     end


### PR DESCRIPTION
- Added get_coordinates and get_vector specialized dispatches: vee and hat do not always seem to dispatch without allocations and there are places where we use get_vector/coordinates.
- Not only SVector for coordinates: we take the coordinates from a larger vector in some places.
 
