### PR TITLE
More random randomness on random (no actually all) Lie groups

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.14] – 2024-01-27
+## [0.9.14] – 2024-01-31
 
 ### Added
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.14] – 2024-01-27
+
+### Added
+
+* `rand` on `UnitaryMatrices`
+* `rand` on arbitrary `GroupManifold`s and manifolds with `IsGroupManifold` trait
+  generating points and elements from the Lie algebra, respectively
+
 ## [0.9.13] – 2024-01-24
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.9.13"
+version = "0.9.14"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -126,21 +126,6 @@ For tangent vectors, an element in the Lie Algebra is generated.
 """
 Random.rand(::GroupManifold; kwargs...)
 
-function Random.rand(
-    ::TraitList{<:IsGroupManifold},
-    M::AbstractDecoratorManifold;
-    vector_at=nothing,
-    kwargs...,
-)
-    if vector_at === nothing
-        pX = allocate_result(M, rand)
-    else
-        pX = allocate_result(M, rand, vector_at)
-    end
-    rand!(M, pX; vector_at=vector_at, kwargs...)
-    return pX
-end
-
 function Random.rand!(
     T::TraitList{<:IsGroupManifold},
     G::AbstractDecoratorManifold,

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -1,8 +1,8 @@
 """
     GroupManifold{𝔽,M<:AbstractManifold{𝔽},O<:AbstractGroupOperation} <: AbstractDecoratorManifold{𝔽}
 
-Concrete Decorator for a smooth manifold that equips the manifold with a group operation, thus making
-it a Lie group. See [`IsGroupManifold`](@ref) for more details.
+Concrete decorator for a smooth manifold that equips the manifold with a group operation,
+thus making it a Lie group. See [`IsGroupManifold`](@ref) for more details.
 
 Group manifolds by default forward metric-related operations to the wrapped manifold.
 
@@ -112,8 +112,8 @@ function is_vector(
 end
 
 @doc raw"""
-    rand(::Groupmanifold; vector_at=nothing, σ=1.0)
-    rand!(::Groupmanifold, pX; vector_at=nothing, kwargs...)
+    rand(::GroupManifold; vector_at=nothing, σ=1.0)
+    rand!(::GroupManifold, pX; vector_at=nothing, kwargs...)
     rand(::TraitList{IsGroupManifold}, M; vector_at=nothing, σ=1.0)
     rand!(TraitList{IsGroupManifold}, M, pX; vector_at=nothing, kwargs...)
 

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -1,15 +1,17 @@
 """
     GroupManifold{𝔽,M<:AbstractManifold{𝔽},O<:AbstractGroupOperation} <: AbstractDecoratorManifold{𝔽}
 
-Decorator for a smooth manifold that equips the manifold with a group operation, thus making
+Concrete Decorator for a smooth manifold that equips the manifold with a group operation, thus making
 it a Lie group. See [`IsGroupManifold`](@ref) for more details.
 
 Group manifolds by default forward metric-related operations to the wrapped manifold.
 
-
 # Constructor
 
     GroupManifold(manifold, op)
+
+Define the group operation `op` acting on the manifold `manifold`, hence if `op` acts smoothly,
+this forms a Lie group.
 """
 struct GroupManifold{𝔽,M<:AbstractManifold{𝔽},O<:AbstractGroupOperation} <:
        AbstractDecoratorManifold{𝔽}
@@ -103,6 +105,64 @@ function is_vector(
         end
     end
     return is_vector(G.manifold, identity_element(G), X, false; error=error, kwargs...)
+end
+
+@doc raw"""
+    rand(::Groupmanifold; vector_at=nothing, σ=1.0)
+    rand!(::Groupmanifold, pX; vector_at=nothing, kwargs...)
+    rand(::TraitList{IsGroupManifold}, M; vector_at=nothing, σ=1.0)
+    rand!(TraitList{IsGroupManifold}, M, pX; vector_at=nothing, kwargs...)
+
+Compute a random point or tangent vector on a Lie group.
+
+For points this just means to generate a random point on the
+underlying manifold itself.
+
+For tangent vectors, an element in the Lie Algebra is generated.
+"""
+Random.rand(::GroupManifold; kwargs...)
+
+function Random.rand(
+    ::TraitList{<:IsGroupManifold},
+    M::AbstractDecoratorManifold;
+    vector_at = nothing,
+    kwargs...
+)
+    if vector_at === nothing
+        pX = allocate_result(M, rand)
+    else
+        pX = allocate_result(M, rand, vector_at)
+    end
+    rand!(M, pX; vector_at = vector_at, kwargs...)
+    return pX
+end
+
+function Random.rand!(
+    T::TraitList{<:IsGroupManifold},
+    G::AbstractDecoratorManifold,
+    pX;
+    kwargs...
+)
+    return rand!(T,Random.default_rng(), G, pX; kwargs...)
+end
+
+function Random.rand!(
+    ::TraitList{<:IsGroupManifold},
+    rng::AbstractRNG,
+    G::AbstractDecoratorManifold,
+    pX;
+    vector_at=nothing,
+    kwargs...
+)
+    M = base_manifold(G)
+    if vector_at === nothing
+        # points we produce the same as on manifolds
+        rand!(rng, M, pX, kwargs...)
+    else
+        # tangent vectors are represented in the Lie algebra
+        # => materialize the identity and produce a tangent vector there
+        rand!(rng, M, pX; vector_at=identity_element(G), kwargs...)
+    end
 end
 
 Base.show(io::IO, G::GroupManifold) = print(io, "GroupManifold($(G.manifold), $(G.op))")

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -125,15 +125,15 @@ Random.rand(::GroupManifold; kwargs...)
 function Random.rand(
     ::TraitList{<:IsGroupManifold},
     M::AbstractDecoratorManifold;
-    vector_at = nothing,
-    kwargs...
+    vector_at=nothing,
+    kwargs...,
 )
     if vector_at === nothing
         pX = allocate_result(M, rand)
     else
         pX = allocate_result(M, rand, vector_at)
     end
-    rand!(M, pX; vector_at = vector_at, kwargs...)
+    rand!(M, pX; vector_at=vector_at, kwargs...)
     return pX
 end
 
@@ -141,9 +141,9 @@ function Random.rand!(
     T::TraitList{<:IsGroupManifold},
     G::AbstractDecoratorManifold,
     pX;
-    kwargs...
+    kwargs...,
 )
-    return rand!(T,Random.default_rng(), G, pX; kwargs...)
+    return rand!(T, Random.default_rng(), G, pX; kwargs...)
 end
 
 function Random.rand!(
@@ -152,7 +152,7 @@ function Random.rand!(
     G::AbstractDecoratorManifold,
     pX;
     vector_at=nothing,
-    kwargs...
+    kwargs...,
 )
     M = base_manifold(G)
     if vector_at === nothing

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -33,6 +33,10 @@ end
         IsExplicitDecorator(),
     )
 end
+# This could maybe even moved to ManifoldsBase?
+@inline function active_traits(f, ::AbstractRNG, M::AbstractDecoratorManifold, args...)
+    return active_traits(f, M, args...)
+end
 
 decorated_manifold(G::GroupManifold) = G.manifold
 

--- a/src/groups/general_unitary_groups.jl
+++ b/src/groups/general_unitary_groups.jl
@@ -287,6 +287,15 @@ function manifold_volume(M::GeneralUnitaryMultiplicationGroup)
     return manifold_volume(M.manifold)
 end
 
+function Random.rand!(G::GeneralUnitaryMultiplicationGroup, pX; kwargs...)
+    rand!(G.manifold, pX; kwargs...)
+    return pX
+end
+function Random.rand!(rng::AbstractRNG, G::GeneralUnitaryMultiplicationGroup, pX; kwargs...)
+    rand!(rng, G.manifold, pX; kwargs...)
+    return pX
+end
+
 function translate_diff!(
     G::GeneralUnitaryMultiplicationGroup,
     Y,

--- a/src/groups/general_unitary_groups.jl
+++ b/src/groups/general_unitary_groups.jl
@@ -287,15 +287,6 @@ function manifold_volume(M::GeneralUnitaryMultiplicationGroup)
     return manifold_volume(M.manifold)
 end
 
-function Random.rand!(G::GeneralUnitaryMultiplicationGroup, pX; kwargs...)
-    rand!(G.manifold, pX; kwargs...)
-    return pX
-end
-function Random.rand!(rng::AbstractRNG, G::GeneralUnitaryMultiplicationGroup, pX; kwargs...)
-    rand!(rng, G.manifold, pX; kwargs...)
-    return pX
-end
-
 function translate_diff!(
     G::GeneralUnitaryMultiplicationGroup,
     Y,

--- a/src/manifolds/ProbabilitySimplexEuclideanMetric.jl
+++ b/src/manifolds/ProbabilitySimplexEuclideanMetric.jl
@@ -21,6 +21,69 @@ function manifold_volume(M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanM
 end
 
 @doc raw"""
+    rand(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}; vector_at=nothing, σ::Real=1.0)
+
+When `vector_at` is `nothing`, return a random (uniform) point `x` on the [`ProbabilitySimplex`](@ref) with the Euclidean metric
+manifold `M` by normalizing independent exponential draws to unit sum, see [Devroye:1986](@cite), Theorems 2.1 and 2.2 on p. 207 and 208, respectively.
+When `vector_at` is not `nothing`, return a (Gaussian) random vector from the tangent space
+``T_{p}\mathrm{\Delta}^n``by shifting a multivariate Gaussian with standard deviation `σ`
+to have a zero component sum.
+"""
+rand(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}; σ::Real=1.0)
+function Random.rand(
+    M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric};
+    vector_at=nothing,
+    kwargs...,
+)
+    if vector_at === nothing
+        pX = allocate_result(M, rand)
+    else
+        pX = allocate_result(M, rand, vector_at)
+    end
+    rand!(M, pX; vector_at=vector_at, kwargs...)
+    return pX
+end
+function Random.rand(
+    rng::AbstractRNG,
+    M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric};
+    vector_at=nothing,
+    kwargs...,
+)
+    if vector_at === nothing
+        pX = allocate_result(M, rand)
+    else
+        pX = allocate_result(M, rand, vector_at)
+    end
+    rand!(rng, M, pX; vector_at=vector_at, kwargs...)
+    return pX
+end
+
+function Random.rand!(
+    rng::AbstractRNG,
+    ::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric},
+    pX;
+    vector_at=nothing,
+    σ=one(eltype(pX)),
+)
+    if isnothing(vector_at)
+        Random.randexp!(rng, pX)
+        LinearAlgebra.normalize!(pX, 1)
+    else
+        Random.randn!(rng, pX)
+        pX .= (pX .- mean(pX)) .* σ
+    end
+    return pX
+end
+
+function Random.rand!(
+    M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric},
+    pX;
+    kwargs...,
+)
+    return rand!(Random.default_rng(), M, pX; kwargs...)
+end
+
+@doc raw"""
     volume_density(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}, p, X)
 
 Compute the volume density at point `p` on [`ProbabilitySimplex`](@ref) `M` for tangent

--- a/src/manifolds/ProbabilitySimplexEuclideanMetric.jl
+++ b/src/manifolds/ProbabilitySimplexEuclideanMetric.jl
@@ -21,37 +21,6 @@ function manifold_volume(M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanM
 end
 
 @doc raw"""
-    rand(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}; vector_at=nothing, σ::Real=1.0)
-
-
-When `vector_at` is `nothing`, return a random (uniform) point `x` on the [`ProbabilitySimplex`](@ref) with the Euclidean metric
-manifold `M` by normalizing independent exponential draws to unit sum, see [Devroye:1986](@cite), Theorems 2.1 and 2.2 on p. 207 and 208, respectively.
-
-When `vector_at` is not `nothing`, return a (Gaussian) random vector from the tangent space
-``T_{p}\mathrm{\Delta}^n``by shifting a multivariate Gaussian with standard deviation `σ`
-to have a zero component sum.
-
-"""
-rand(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}; σ::Real=1.0)
-
-function Random.rand!(
-    rng::AbstractRNG,
-    M::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric},
-    pX;
-    vector_at=nothing,
-    σ=one(eltype(pX)),
-)
-    if isnothing(vector_at)
-        Random.randexp!(rng, pX)
-        LinearAlgebra.normalize!(pX, 1)
-    else
-        Random.randn!(rng, pX)
-        pX .= (pX .- mean(pX)) .* σ
-    end
-    return pX
-end
-
-@doc raw"""
     volume_density(::MetricManifold{ℝ,<:ProbabilitySimplex,<:EuclideanMetric}, p, X)
 
 Compute the volume density at point `p` on [`ProbabilitySimplex`](@ref) `M` for tangent

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -127,15 +127,6 @@ where ``\operatorname{Sym}(q)`` is the symmetrization of ``q``, e.g. by
 """
 project(::UnitaryMatrices, ::Any...)
 
-function project!(::UnitaryMatrices, Y, p, X)
-    A = p' * X
-    T = eltype(Y)
-    copyto!(Y, X)
-    mul!(Y, p, A + A', T(-0.5), true)
-    ldiv!(qr(p), Y) # different than Stiefel we store this in the Lie algebra already
-    return Y
-end
-
 function Random.rand(M::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}; vector_at=nothing)
     if vector_at === nothing
         return sign(rand(Quaternions.QuaternionF64))

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -134,7 +134,7 @@ end
 @doc raw"""
     rand(::Unitary; vector_at=nothing, σ::Real=1.0)
 
-Gereate a random point on the [`UnitaryMatrices`](@ref) manifold,
+Generate a random point on the [`UnitaryMatrices`](@ref) manifold,
 if `vector_at` is nothing, by computing the QR decomposition of
 a ``n×x`` matrix.
 

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -113,21 +113,6 @@ project(::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}, p) = sign(p)
 project(::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}, p, X) = (X - conj(X)) / 2
 
 @doc raw"""
-    project(M::UnitaryMatrices,p)
-
-Projects `p` from the embedding onto the [`UnitaryMatrices`](@ref) `M`, i.e. compute `q`
-as the polar decomposition of ``p`` such that ``q^{\mathrm{H}}q`` is the identity,
-where ``⋅^{\mathrm{H}}`` denotes the hermitian, i.e. complex conjugate transposed.
-"""
-project(::UnitaryMatrices, ::Any, ::Any)
-
-function project!(::UnitaryMatrices, q, p)
-    s = svd(p)
-    mul!(q, s.U, s.Vt)
-    return q
-end
-
-@doc raw"""
     project(M::UnitaryMatrices, p, X)
 
 Project `X` onto the tangent space of `p` to the [`UnitaryMatrices`](@ref) manifold `M`.

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -112,21 +112,6 @@ project(::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}, p) = sign(p)
 
 project(::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}, p, X) = (X - conj(X)) / 2
 
-@doc raw"""
-    project(M::UnitaryMatrices, p, X)
-
-Project `X` onto the tangent space of `p` to the [`UnitaryMatrices`](@ref) manifold `M`.
-The formula reads
-
-````math
-\operatorname{proj}_{T_p\mathcal M}(X) = X - p \operatorname{Sym}(p^{\mathrm{H}}X),
-````
-
-where ``\operatorname{Sym}(q)`` is the symmetrization of ``q``, e.g. by
-``\operatorname{Sym}(q) = \frac{q^{\mathrm{H}}+q}{2}``.
-"""
-project(::UnitaryMatrices, ::Any...)
-
 function Random.rand(M::UnitaryMatrices{TypeParameter{Tuple{1}},ℍ}; vector_at=nothing)
     if vector_at === nothing
         return sign(rand(Quaternions.QuaternionF64))

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -130,6 +130,22 @@ function Random.rand(
     end
 end
 
+function Random.rand!(
+    rng::AbstractRNG,
+    M::UnitaryMatrices,
+    pX;
+    vector_at=nothing,
+)
+    if vector_at === nothing
+        rand!(rng, pX)
+        project!(M, pX, pX)
+    else
+        rand!(rng, pX)
+        project(M, pX, vector_at, pX)
+    end
+    return pX
+end
+
 function Base.show(io::IO, ::UnitaryMatrices{TypeParameter{Tuple{n}},ℂ}) where {n}
     return print(io, "UnitaryMatrices($(n))")
 end

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -130,17 +130,6 @@ function Random.rand(
     end
 end
 
-function Random.rand!(rng::AbstractRNG, M::UnitaryMatrices, pX; vector_at=nothing)
-    if vector_at === nothing
-        rand!(rng, pX)
-        project!(M, pX, pX)
-    else
-        rand!(rng, pX)
-        project(M, pX, vector_at, pX)
-    end
-    return pX
-end
-
 function Base.show(io::IO, ::UnitaryMatrices{TypeParameter{Tuple{n}},ℂ}) where {n}
     return print(io, "UnitaryMatrices($(n))")
 end

--- a/src/manifolds/Unitary.jl
+++ b/src/manifolds/Unitary.jl
@@ -130,12 +130,7 @@ function Random.rand(
     end
 end
 
-function Random.rand!(
-    rng::AbstractRNG,
-    M::UnitaryMatrices,
-    pX;
-    vector_at=nothing,
-)
+function Random.rand!(rng::AbstractRNG, M::UnitaryMatrices, pX; vector_at=nothing)
     if vector_at === nothing
         rand!(rng, pX)
         project!(M, pX, pX)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,7 +210,7 @@ unrealify!(Y, X, ::typeof(ℝ), args...) = copyto!(Y, X)
 @doc raw"""
     symmetrize!(Y, X)
 
-Given a quare matrix `X` compute `1/2 .* (X' + X)` in place of `Y`
+Given a square matrix `X` compute `1/2 .* (X' + X)` in place of `Y`.
 """
 function symmetrize!(Y, X)
     Y .= (X' .+ X) ./ 2
@@ -220,7 +220,7 @@ end
 @doc raw"""
     symmetrize(X)
 
-Given a quare matrix `X` compute `1/2 .* (X' + X)`.
+Given a square matrix `X` compute `1/2 .* (X' + X)`.
 """
 function symmetrize(X)
     return (X' .+ X) ./ 2
@@ -229,7 +229,7 @@ end
 @doc raw"""
     vec2skew!(X, v, k)
 
-create a skew symmetric matrix inplace in `X` of size ``k×k`` from a vector `v`,
+Create a skew symmetric matrix in-place in `X` of size ``k×k`` from a vector `v`,
 for example for `v=[1,2,3]` and `k=3` this
 yields
 ````julia

--- a/test/manifolds/probability_simplex.jl
+++ b/test/manifolds/probability_simplex.jl
@@ -78,7 +78,7 @@ include("../header.jl")
                 test_vee_hat=false,
                 is_tangent_atol_multiplier=40.0,
                 default_inverse_retraction_method=nothing,
-                test_inplace=false,
+                test_inplace=true,
                 test_rand_point=true,
                 test_rand_tvector=true,
                 rand_tvector_atol_multiplier=40.0,

--- a/test/manifolds/unitary_matrices.jl
+++ b/test/manifolds/unitary_matrices.jl
@@ -59,6 +59,22 @@ end
     r1 = exp(M, p, X, 1.0)
     @test isapprox(M, r, r1; atol=1e-10)
 
+    @testset "Projection" begin
+        M = UnitaryMatrices(2)
+        pE = [2im 0.0; 0.0 2im]
+        p = project(M, pE)
+        @test is_point(M, p; error=:error)
+        pE[2, 1] = 1.0
+        X = project(M, p, pE)
+        @test is_vector(M, p, X; error=:error)
+    end
+    @testset "Random" begin
+        M = UnitaryMatrices(2)
+        Random.seed!(23)
+        p = rand(M)
+        @test is_point(M, p; error=:error)
+        @test is_vector(M, p, rand(M; vector_at=p); error=:error)
+    end
     @testset "Riemannian Hessian" begin
         p = Matrix{Float64}(I, 2, 2)
         X = [0.0 3.0; -3.0 0.0]


### PR DESCRIPTION
This small fix could even reduce other Lie groups random implementations

* [x] adds `rand` to `UnitaryMatrices`
* [x] adds. a “passthrough” for points on Lie groups (to ask the manifold) and tangent vectors to generate tangent vectors at the identity
* [x] text coverage
* [x] check whether other Lie algebras implicitly do that already and now explicitly could use this generic default instead. 