### PR TITLE
Fix several typos in the docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.15] unreleased
+
+## Fixed
+
+* several typographical errors in the docs
+* unifies to use two backticks ``` `` ``` for math instead of ` $ ` further in the docs
+
 ## [0.9.14] – 2024-01-31
 
 ### Added

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -70,6 +70,8 @@ makedocs(;
     format=Documenter.HTML(
         prettyurls=false,
         assets=["assets/favicon.ico", "assets/citations.css"],
+        size_threshold_warn=200 * 2^10, # raise slightly from 100 to 200 KiB
+        size_threshold=300 * 2^10,      # raise slightly 200 to to 300 KiB
     ),
     modules=[
         Manifolds,

--- a/docs/src/manifolds/rotations.md
+++ b/docs/src/manifolds/rotations.md
@@ -2,8 +2,10 @@
 
 The manifold ``\mathrm{SO}(n)`` of orthogonal matrices with determinant ``+1`` in ``ℝ^{n×n}``, i.e.
 
-``\mathrm{SO}(n) = \bigl\{R ∈ ℝ^{n×n} \big| R R^{\mathrm{T}} =
-R^{\mathrm{T}}R = I_n, \det(R) = 1 \bigr\}$
+```math
+\mathrm{SO}(n) = \bigl\{R ∈ ℝ^{n×n} \big| R R^{\mathrm{T}} =
+R^{\mathrm{T}}R = I_n, \det(R) = 1 \bigr\}
+```
 
 The Lie group ``\mathrm{SO}(n)`` is a subgroup of the orthogonal group ``\mathrm{O}(n)`` and also known as the special orthogonal group or the set of rotations group.
 See also [`SpecialOrthogonal`](@ref), which is this manifold equipped with the group operation.
@@ -24,7 +26,7 @@ This convention allows for more efficient operations on tangent vectors.
 Tangent spaces at different points are different vector spaces.
 
 Let ``L_R: \mathrm{SO}(n) → \mathrm{SO}(n)`` where ``R ∈ \mathrm{SO}(n)`` be the left-multiplication by ``R``, that is ``L_R(S) = RS``.
-The tangent space at rotation ``R``, ``T_R \mathrm{SO}(n)``, is related to the tangent space at the identity rotation ``I_n`` by the differential of ``L_R`` at identity, $(\mathrm{d}L_R)_{I_n} : T_{I_n} \mathrm{SO}(n) → T_R \mathrm{SO}(n)``.
+The tangent space at rotation ``R``, ``T_R \mathrm{SO}(n)``, is related to the tangent space at the identity rotation ``I_n`` by the differential of ``L_R`` at identity, ``(\mathrm{d}L_R)_{I_n} : T_{I_n} \mathrm{SO}(n) → T_R \mathrm{SO}(n)``.
 To convert the tangent vector representation at the identity rotation ``X ∈ T_{I_n} \mathrm{SO}(n)`` (i.e., the default) to the matrix representation of the corresponding tangent vector ``Y`` at a rotation ``R`` use the [`embed`](@ref embed(::Manifolds.Rotations, :Any...)) which implements the following multiplication: ``Y = RX ∈ T_R \mathrm{SO}(n)``.
 You can compare the functions [`log`](@ref log(::Manifolds.Rotations, :Any...)) and [`exp`](@ref exp(::Manifolds.Rotations, ::Any...)) to see how it works in practice.
 

--- a/docs/src/manifolds/symplecticstiefel.md
+++ b/docs/src/manifolds/symplecticstiefel.md
@@ -2,12 +2,12 @@
 
 The [`SymplecticStiefel`](@ref) manifold, denoted ``\operatorname{SpSt}(2n, 2k)``,
 represents canonical symplectic bases of ``2k`` dimensonal symplectic subspaces of ``ℝ^{2n×2n}``.
-This means that the columns of each element ``p \in \operatorname{SpSt}(2n, 2k) \subset ℝ^{2n×2k}$
+This means that the columns of each element ``p \in \operatorname{SpSt}(2n, 2k) \subset ℝ^{2n×2k}``
 constitute a canonical symplectic basis of ``\operatorname{span}(p)``.
 The canonical symplectic form is a non-degenerate, bilinear, and skew symmetric map
-``\omega_{2k}\colon 𝔽^{2k}×𝔽^{2k}
-→ 𝔽``, given by
+``\omega_{2k}\colon 𝔽^{2k}×𝔽^{2k} → 𝔽``, given by
 ``\omega_{2k}(x, y) = x^T Q_{2k} y`` for elements ``x, y \in 𝔽^{2k}``, with
+
 ````math
     Q_{2k} =
     \begin{bmatrix}
@@ -15,10 +15,13 @@ The canonical symplectic form is a non-degenerate, bilinear, and skew symmetric 
     -I_k  &  0_k
     \end{bmatrix}.
 ````
+
 Specifically given an element ``p \in \operatorname{SpSt}(2n, 2k)`` we require that
+
 ````math
     \omega_{2n} (p x, p y) = x^T(p^TQ_{2n}p)y = x^TQ_{2k}y = \omega_{2k}(x, y) \;\forall\; x, y \in 𝔽^{2k},
 ````
+
 leading to the requirement on ``p`` that ``p^TQ_{2n}p = Q_{2k}``.
 In the case that ``k = n``, this manifold reduces to the [`SymplecticMatrices`](@ref) manifold, which is also known as the symplectic group.
 

--- a/docs/src/manifolds/tucker.md
+++ b/docs/src/manifolds/tucker.md
@@ -7,3 +7,8 @@ Order = [:type, :function]
 ```
 
 ## Literature
+
+```@bibliography
+Pages = ["tucker.md"]
+Canonical=false
+```

--- a/src/groups/special_euclidean.jl
+++ b/src/groups/special_euclidean.jl
@@ -1,16 +1,16 @@
 @doc raw"""
     SpecialEuclidean(n)
 
-Special Euclidean group $\mathrm{SE}(n)$, the group of rigid motions.
+Special Euclidean group ``\mathrm{SE}(n)``, the group of rigid motions.
 
-``\mathrm{SE}(n)`` is the semidirect product of the [`TranslationGroup`](@ref) on $ℝ^n$ and
+``\mathrm{SE}(n)`` is the semidirect product of the [`TranslationGroup`](@ref) on ``ℝ^n`` and
 [`SpecialOrthogonal`](@ref)`(n)`
 
 ````math
 \mathrm{SE}(n) ≐ \mathrm{T}(n) ⋊_θ \mathrm{SO}(n),
 ````
 
-where ``θ`` is the canonical action of ``\mathrm{SO}(n)`` on $\mathrm{T}(n)$ by vector rotation.
+where ``θ`` is the canonical action of ``\mathrm{SO}(n)`` on ``\mathrm{T}(n)`` by vector rotation.
 
 This constructor is equivalent to calling
 
@@ -20,8 +20,8 @@ SOn = SpecialOrthogonal(n)
 SemidirectProductGroup(Tn, SOn, RotationAction(Tn, SOn))
 ```
 
-Points on $\mathrm{SE}(n)$ may be represented as points on the underlying product manifold
-$\mathrm{T}(n) × \mathrm{SO}(n)$. For group-specific functions, they may also be
+Points on ``\mathrm{SE}(n)`` may be represented as points on the underlying product manifold
+``\mathrm{T}(n) × \mathrm{SO}(n)``. For group-specific functions, they may also be
 represented as affine matrices with size `(n + 1, n + 1)` (see [`affine_matrix`](@ref)), for
 which the group operation is [`MultiplicationOperation`](@ref).
 """
@@ -167,9 +167,9 @@ end
 @doc raw"""
     affine_matrix(G::SpecialEuclidean, p) -> AbstractMatrix
 
-Represent the point $p ∈ \mathrm{SE}(n)$ as an affine matrix.
-For $p = (t, R) ∈ \mathrm{SE}(n)$, where $t ∈ \mathrm{T}(n), R ∈ \mathrm{SO}(n)$, the
-affine representation is the $n + 1 × n + 1$ matrix
+Represent the point ``p ∈ \mathrm{SE}(n)`` as an affine matrix.
+For ``p = (t, R) ∈ \mathrm{SE}(n)``, where ``t ∈ \mathrm{T}(n), R ∈ \mathrm{SO}(n)``, the
+affine representation is the ``n + 1 × n + 1`` matrix
 
 ````math
 \begin{pmatrix}
@@ -178,7 +178,7 @@ R & t \\
 \end{pmatrix}.
 ````
 
-This function embeds $\mathrm{SE}(n)$ in the general linear group $\mathrm{GL}(n+1)$.
+This function embeds ``\mathrm{SE}(n)`` in the general linear group ``\mathrm{GL}(n+1)``.
 It is an isometric embedding and group homomorphism [RicoMartinez:1988](@cite).
 
 See also [`screw_matrix`](@ref) for matrix representations of the Lie algebra.
@@ -278,9 +278,9 @@ end
 @doc raw"""
     screw_matrix(G::SpecialEuclidean, X) -> AbstractMatrix
 
-Represent the Lie algebra element $X ∈ 𝔰𝔢(n) = T_e \mathrm{SE}(n)$ as a screw matrix.
-For $X = (b, Ω) ∈ 𝔰𝔢(n)$, where $Ω ∈ 𝔰𝔬(n) = T_e \mathrm{SO}(n)$, the screw representation is
-the $n + 1 × n + 1$ matrix
+Represent the Lie algebra element ``X ∈ 𝔰𝔢(n) = T_e \mathrm{SE}(n)`` as a screw matrix.
+For ``X = (b, Ω) ∈ 𝔰𝔢(n)``, where ``Ω ∈ 𝔰𝔬(n) = T_e \mathrm{SO}(n)``, the screw representation is
+the ``n + 1 × n + 1`` matrix
 
 ````math
 \begin{pmatrix}
@@ -289,7 +289,7 @@ the $n + 1 × n + 1$ matrix
 \end{pmatrix}.
 ````
 
-This function embeds $𝔰𝔢(n)$ in the general linear Lie algebra $𝔤𝔩(n+1)$ but it's not
+This function embeds ``𝔰𝔢(n)`` in the general linear Lie algebra ``𝔤𝔩(n+1)`` but it's not
 a homomorphic embedding (see [`SpecialEuclideanInGeneralLinear`](@ref) for a homomorphic one).
 
 See also [`affine_matrix`](@ref) for matrix representations of the Lie group.
@@ -351,13 +351,13 @@ end
 @doc raw"""
     exp_lie(G::SpecialEuclidean{n}, X)
 
-Compute the group exponential of $X = (b, Ω) ∈ 𝔰𝔢(n)$, where $b ∈ 𝔱(n)$ and $Ω ∈ 𝔰𝔬(n)$:
+Compute the group exponential of ``X = (b, Ω) ∈ 𝔰𝔢(n)``, where ``b ∈ 𝔱(n)`` and ``Ω ∈ 𝔰𝔬(n)``:
 
 ````math
 \exp X = (t, R),
 ````
 
-where $t ∈ \mathrm{T}(n)$ and $R = \exp Ω$ is the group exponential on $\mathrm{SO}(n)$.
+where ``t ∈ \mathrm{T}(n)`` and ``R = \exp Ω`` is the group exponential on ``\mathrm{SO}(n)``.
 
 In the [`screw_matrix`](@ref) representation, the group exponential is the matrix
 exponential (see [`exp_lie`](@ref)).
@@ -367,19 +367,19 @@ exp_lie(::SpecialEuclidean, ::Any)
 @doc raw"""
     exp_lie(G::SpecialEuclidean{TypeParameter{Tuple{2}}}, X)
 
-Compute the group exponential of $X = (b, Ω) ∈ 𝔰𝔢(2)$, where $b ∈ 𝔱(2)$ and $Ω ∈ 𝔰𝔬(2)$:
+Compute the group exponential of ``X = (b, Ω) ∈ 𝔰𝔢(2)``, where ``b ∈ 𝔱(2)`` and ``Ω ∈ 𝔰𝔬(2)``:
 
 ````math
 \exp X = (t, R) = (U(θ) b, \exp Ω),
 ````
 
-where $t ∈ \mathrm{T}(2)$, $R = \exp Ω$ is the group exponential on $\mathrm{SO}(2)$,
+where ``t ∈ \mathrm{T}(2)``, ``R = \exp Ω`` is the group exponential on ``\mathrm{SO}(2)``,
 
 ````math
 U(θ) = \frac{\sin θ}{θ} I_2 + \frac{1 - \cos θ}{θ^2} Ω,
 ````
 
-and $θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e$
+and ``θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e``
 (see [`norm`](@ref norm(M::Rotations, p, X))) is the angle of the rotation.
 """
 exp_lie(::SpecialEuclidean{TypeParameter{Tuple{2}}}, ::Any)
@@ -387,19 +387,19 @@ exp_lie(::SpecialEuclidean{TypeParameter{Tuple{2}}}, ::Any)
 @doc raw"""
     exp_lie(G::SpecialEuclidean{TypeParameter{Tuple{3}}}, X)
 
-Compute the group exponential of $X = (b, Ω) ∈ 𝔰𝔢(3)$, where $b ∈ 𝔱(3)$ and $Ω ∈ 𝔰𝔬(3)$:
+Compute the group exponential of ``X = (b, Ω) ∈ 𝔰𝔢(3)``, where ``b ∈ 𝔱(3)`` and ``Ω ∈ 𝔰𝔬(3)``:
 
 ````math
 \exp X = (t, R) = (U(θ) b, \exp Ω),
 ````
 
-where $t ∈ \mathrm{T}(3)$, $R = \exp Ω$ is the group exponential on $\mathrm{SO}(3)$,
+where ``t ∈ \mathrm{T}(3)``, ``R = \exp Ω`` is the group exponential on ``\mathrm{SO}(3)``,
 
 ````math
 U(θ) = I_3 + \frac{1 - \cos θ}{θ^2} Ω + \frac{θ - \sin θ}{θ^3} Ω^2,
 ````
 
-and $θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e$
+and ``θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e``
 (see [`norm`](@ref norm(M::Rotations, p, X))) is the angle of the rotation.
 """
 exp_lie(::SpecialEuclidean{TypeParameter{Tuple{3}}}, ::Any)
@@ -471,14 +471,14 @@ end
 @doc raw"""
     log_lie(G::SpecialEuclidean, p)
 
-Compute the group logarithm of $p = (t, R) ∈ \mathrm{SE}(n)$, where $t ∈ \mathrm{T}(n)$
-and $R ∈ \mathrm{SO}(n)$:
+Compute the group logarithm of ``p = (t, R) ∈ \mathrm{SE}(n)``, where ``t ∈ \mathrm{T}(n)``
+and ``R ∈ \mathrm{SO}(n)``:
 
 ````math
 \log p = (b, Ω),
 ````
 
-where $b ∈ 𝔱(n)$ and $Ω = \log R ∈ 𝔰𝔬(n)$ is the group logarithm on $\mathrm{SO}(n)$.
+where ``b ∈ 𝔱(n)`` and ``Ω = \log R ∈ 𝔰𝔬(n)`` is the group logarithm on ``\mathrm{SO}(n)``.
 
 In the [`affine_matrix`](@ref) representation, the group logarithm is the matrix logarithm
 (see [`log_lie`](@ref)):
@@ -488,20 +488,20 @@ log_lie(::SpecialEuclidean, ::Any)
 @doc raw"""
     log_lie(G::SpecialEuclidean{TypeParameter{Tuple{2}}}, p)
 
-Compute the group logarithm of $p = (t, R) ∈ \mathrm{SE}(2)$, where $t ∈ \mathrm{T}(2)$
-and $R ∈ \mathrm{SO}(2)$:
+Compute the group logarithm of ``p = (t, R) ∈ \mathrm{SE}(2)``, where ``t ∈ \mathrm{T}(2)``
+and ``R ∈ \mathrm{SO}(2)``:
 
 ````math
 \log p = (b, Ω) = (U(θ)^{-1} t, \log R),
 ````
 
-where $b ∈ 𝔱(2)$, $Ω = \log R ∈ 𝔰𝔬(2)$ is the group logarithm on $\mathrm{SO}(2)$,
+where ``b ∈ 𝔱(2)``, ``Ω = \log R ∈ 𝔰𝔬(2)`` is the group logarithm on ``\mathrm{SO}(2)``,
 
 ````math
 U(θ) = \frac{\sin θ}{θ} I_2 + \frac{1 - \cos θ}{θ^2} Ω,
 ````
 
-and $θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e$
+and ``θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e``
 (see [`norm`](@ref norm(M::Rotations, p, X))) is the angle of the rotation.
 """
 log_lie(::SpecialEuclidean{TypeParameter{Tuple{2}}}, ::Any)
@@ -509,20 +509,20 @@ log_lie(::SpecialEuclidean{TypeParameter{Tuple{2}}}, ::Any)
 @doc raw"""
     log_lie(G::SpecialEuclidean{TypeParameter{Tuple{3}}}, p)
 
-Compute the group logarithm of $p = (t, R) ∈ \mathrm{SE}(3)$, where $t ∈ \mathrm{T}(3)$
-and $R ∈ \mathrm{SO}(3)$:
+Compute the group logarithm of ``p = (t, R) ∈ \mathrm{SE}(3)``, where ``t ∈ \mathrm{T}(3)``
+and ``R ∈ \mathrm{SO}(3)``:
 
 ````math
 \log p = (b, Ω) = (U(θ)^{-1} t, \log R),
 ````
 
-where $b ∈ 𝔱(3)$, $Ω = \log R ∈ 𝔰𝔬(3)$ is the group logarithm on $\mathrm{SO}(3)$,
+where ``b ∈ 𝔱(3)``, ``Ω = \log R ∈ 𝔰𝔬(3)`` is the group logarithm on ``\mathrm{SO}(3)``,
 
 ````math
 U(θ) = I_3 + \frac{1 - \cos θ}{θ^2} Ω + \frac{θ - \sin θ}{θ^3} Ω^2,
 ````
 
-and $θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e$
+and ``θ = \frac{1}{\sqrt{2}} \lVert Ω \rVert_e``
 (see [`norm`](@ref norm(M::Rotations, p, X))) is the angle of the rotation.
 """
 log_lie(::SpecialEuclidean{TypeParameter{Tuple{3}}}, ::Any)
@@ -647,8 +647,8 @@ end
 @doc raw"""
     SpecialEuclideanInGeneralLinear
 
-An explicit isometric and homomorphic embedding of $\mathrm{SE}(n)$ in $\mathrm{GL}(n+1)$
-and $𝔰𝔢(n)$ in $𝔤𝔩(n+1)$.
+An explicit isometric and homomorphic embedding of ``\mathrm{SE}(n)`` in ``\mathrm{GL}(n+1)``
+and ``𝔰𝔢(n)`` in ``𝔤𝔩(n+1)``.
 Note that this is *not* a transparently isometric embedding.
 
 # Constructor

--- a/src/manifolds/EssentialManifold.jl
+++ b/src/manifolds/EssentialManifold.jl
@@ -26,7 +26,7 @@ with the quotient space
 \mathcal{M}_{\text{E}} := (\text{SO}(3)×\text{SO}(3))/(H_z × H_π),
 ````
 
-and for the signed Essential manifold $\mathcal{M}_{\text{Ǝ}}$, the quotient reads
+and for the signed Essential manifold ``\mathcal{M}_{\text{Ǝ}}``, the quotient reads
 
 ````math
 \mathcal{M}_{\text{Ǝ}} := (\text{SO}(3)×\text{SO}(3))/(H_z).
@@ -39,7 +39,7 @@ E = (R'_1)^T [T'_2 - T'_1]_{×} R'_2,
 ````
 
 where the poses of two cameras ``(R_i', T_i'), i=1,2``, are contained in the space of
-rigid body transformations $SE(3)$ and the operator $[⋅]_{×}\colon ℝ^3 → \operatorname{SkewSym}(3)$
+rigid body transformations ``SE(3)`` and the operator ``[⋅]_{×}\colon ℝ^3 → \operatorname{SkewSym}(3)``
 denotes the matrix representation of the cross product operator. For more details see [TronDaniilidis:2017](@cite).
 
 # Constructor
@@ -92,8 +92,8 @@ end
     distance(M::EssentialManifold, p, q)
 
 Compute the Riemannian distance between the two points `p` and `q` on the [`EssentialManifold`](@ref). This is done by
-computing the distance of the equivalence classes $[p]$ and $[q]$ of the points
-$p=(R_{p_1},R_{p_2}), q=(R_{q_1},R_{q_2}) ∈ SO(3)^2$, respectively. Two points in $SO(3)^2$ are equivalent iff their
+computing the distance of the equivalence classes ``[p]`` and ``[q]`` of the points
+``p=(R_{p_1},R_{p_2}), q=(R_{q_1},R_{q_2}) ∈ SO(3)^2``, respectively. Two points in ``SO(3)^2`` are equivalent iff their
 corresponding essential matrices, given by
 ````math
 E = R_1^T [e_z]_{×}R_2,
@@ -102,12 +102,12 @@ are equal (up to a sign flip). Using the logarithmic map, the distance is given 
 ````math
 \text{dist}([p],[q]) = \| \text{log}_{[p]} [q] \| = \| \log_p (S_z(t_{\text{opt}})q) \|,
 ````
-where $S_z ∈ H_z = \{(R_z(θ),R_z(θ))\colon θ \in [-π,π) \}$ in which $R_z(θ)$ is the rotation around the z axis with angle
-``θ`` and $t_{\text{opt}}$ is the minimizer of the cost function
+where ``S_z ∈ H_z = \{(R_z(θ),R_z(θ))\colon θ \in [-π,π) \}`` in which ``R_z(θ)`` is the rotation around the z axis with angle
+``θ`` and ``t_{\text{opt}}`` is the minimizer of the cost function
 ````math
 f(t) = f_1 + f_2, \quad f_i = \frac{1}{2} θ^2_i(t), \quad θ_i(t)=d(R_{p_i},R_z(t)R_{b_i}) \text{ for } i=1,2,
 ````
-where $d(⋅,⋅)$ is the distance function in $SO(3)$ [TronDaniilidis:2017](@cite).
+where ``d(⋅,⋅)`` is the distance function in ``SO(3)`` [TronDaniilidis:2017](@cite).
 """
 distance(M::EssentialManifold, p, q) = norm(M, p, log(M, p, q))
 
@@ -119,7 +119,7 @@ Compute the exponential map on the [`EssentialManifold`](@ref) from `p` into dir
 ````math
 \text{exp}_p(X) =\text{exp}_g( \tilde X),  \quad g \in \text(SO)(3)^2,
 ````
-where $\tilde X$ is the horizontal lift of ``X``[TronDaniilidis:2017](@cite).
+where ``\tilde X`` is the horizontal lift of ``X``[TronDaniilidis:2017](@cite).
 """
 exp(::EssentialManifold, ::Any...)
 
@@ -146,31 +146,31 @@ is_flat(M::EssentialManifold) = false
     log(M::EssentialManifold, p, q)
 
 Compute the logarithmic map on the [`EssentialManifold`](@ref) `M`, i.e. the tangent vector,
-whose geodesic starting from `p` reaches `q` after time 1. Here, $p=(R_{p_1},R_{p_2})$ and
-$q=(R_{q_1},R_{q_2})$ are elements of $SO(3)^2$. We use that any essential matrix can, up to
+whose geodesic starting from `p` reaches `q` after time 1. Here, ``p=(R_{p_1},R_{p_2})`` and
+``q=(R_{q_1},R_{q_2})`` are elements of ``SO(3)^2``. We use that any essential matrix can, up to
 scale, be decomposed to
 ````math
 E = R_1^T [e_z]_{×}R_2,
 ````
-where $(R_1,R_2)∈SO(3)^2$. Two points in $SO(3)^2$ are equivalent iff their corresponding
+where ``(R_1,R_2)∈SO(3)^2``. Two points in ``SO(3)^2`` are equivalent iff their corresponding
 essential matrices are equal (up to a sign flip).
 To compute the logarithm, we first move `q` to another representative of its equivalence class.
-For this, we find $t= t_{\text{opt}}$ for which the function
+For this, we find ``t= t_{\text{opt}}`` for which the function
 ````math
 f(t) = f_1 + f_2, \quad f_i = \frac{1}{2} θ^2_i(t), \quad θ_i(t)=d(R_{p_i},R_z(t)R_{b_i}) \text{ for } i=1,2,
 ````
-where $d(⋅,⋅)$ is the distance function in $SO(3)$, is minimized. Further, the group $H_z$ acting
-on the left on $SO(3)^2$ is defined as
+where ``d(⋅,⋅)`` is the distance function in ``SO(3)``, is minimized. Further, the group ``H_z`` acting
+on the left on ``SO(3)^2`` is defined as
 ````math
 H_z = \{(R_z(θ),R_z(θ))\colon θ \in [-π,π) \},
 ````
-where $R_z(θ)$ is the rotation around the z axis with angle ``θ``. Points in $H_z$ are denoted by
-$S_z$. Then, the logarithm is defined
+where ``R_z(θ)`` is the rotation around the z axis with angle ``θ``. Points in ``H_z`` are denoted by
+``S_z``. Then, the logarithm is defined
 as
 ````math
 \log_p (S_z(t_{\text{opt}})q) = [\text{Log}(R_{p_i}^T R_z(t_{\text{opt}})R_{b_i})]_{i=1,2},
 ````
-where $\text{Log}$ is the [`logarithm`](@ref log(::Rotations, ::Any...)) on $SO(3)$. For more
+where ``\text{Log}`` is the [`logarithm`](@ref log(::Rotations, ::Any...)) on ``SO(3)``. For more
 details see [TronDaniilidis:2017](@cite).
 """
 log(M::EssentialManifold, ::Any, ::Any)
@@ -221,8 +221,8 @@ This function computes the global minimizer of the function
 ````math
 f(t) = f_1 + f_2, \quad f_i = \frac{1}{2} θ^2_i(t), \quad θ_i(t)=d(R_{p_i},R_z(t)R_{b_i}) \text{ for } i=1,2,
 ````
-for the given values. This is done by finding the discontinuity points $t_{d_i}, i=1,2$ of its derivative
-and using Newton's method to minimize the function over the intervals $[t_{d_1},t_{d_2}]$ and $[t_{d_2},t_{d_1}+2π]$
+for the given values. This is done by finding the discontinuity points ``t_{d_i}, i=1,2`` of its derivative
+and using Newton's method to minimize the function over the intervals ``[t_{d_1},t_{d_2}]`` and ``[t_{d_2},t_{d_1}+2π]``
 separately. Then, the minimizer for which ``f`` is minimal is chosen and given back together with the minimal value.
 For more details see Algorithm 1 in [TronDaniilidis:2017](@cite).
 """
@@ -319,11 +319,11 @@ end
 @doc raw"""
     dist_min_angle_pair_discontinuity_distance(q)
 
-This function computes the point $t_{\text{di}}$ for which the first derivative of
+This function computes the point ``t_{\text{di}}`` for which the first derivative of
 ````math
 f(t) = f_1 + f_2, \quad f_i = \frac{1}{2} θ^2_i(t), \quad θ_i(t)=d(R_{p_i},R_z(t)R_{b_i}) \text{ for } i=1,2,
 ````
-does not exist. This is the case for $\sin(θ_i(t_{\text{di}})) = 0$. For more details see Proposition 9
+does not exist. This is the case for ``\sin(θ_i(t_{\text{di}})) = 0``. For more details see Proposition 9
 and its proof, as well as Lemma 1 in [TronDaniilidis:2017](@cite).
 """
 function dist_min_angle_pair_discontinuity_distance(q)
@@ -341,7 +341,7 @@ end
 @doc raw"""
     dist_min_angle_pair_compute_df_break(t_break, q)
 
-This function computes the derivatives of each term $f_i, i=1,2,$ at discontinuity point `t_break`. For more details see [TronDaniilidis:2017](@cite).
+This function computes the derivatives of each term ``f_i, i=1,2,`` at discontinuity point `t_break`. For more details see [TronDaniilidis:2017](@cite).
 """
 function dist_min_angle_pair_compute_df_break(t_break, q)
     c = cos(t_break)
@@ -420,13 +420,13 @@ Project the matrix `X` onto the tangent space
 ````math
 T_{p} \text{SO}(3)^2 = T_{\text{vp}}\text{SO}(3)^2 ⊕ T_{\text{hp}}\text{SO}(3)^2,
 ````
-by first computing its projection onto the vertical space $T_{\text{vp}}\text{SO}(3)^2$ using [`vert_proj`](@ref).
-Then the orthogonal projection of `X` onto the horizontal space $T_{\text{hp}}\text{SO}(3)^2$ is defined as
+by first computing its projection onto the vertical space ``T_{\text{vp}}\text{SO}(3)^2`` using [`vert_proj`](@ref).
+Then the orthogonal projection of `X` onto the horizontal space ``T_{\text{hp}}\text{SO}(3)^2`` is defined as
 ````math
 \Pi_h(X) = X - \frac{\text{vert\_proj}_p(X)}{2} \begin{bmatrix} R_1^T e_z \\ R_2^T e_z \end{bmatrix},
 ````
-with $R_i = R_0 R'_i, i=1,2,$ where $R'_i$ is part of the pose of camera ``i`` $g_i = (R'_i,T'_i) ∈ \text{SE}(3)$
-and $R_0 ∈ \text{SO}(3)$ such that $R_0(T'_2-T'_1) = e_z$.
+with ``R_i = R_0 R'_i, i=1,2,`` where ``R'_i`` is part of the pose of camera ``i`` ``g_i = (R'_i,T'_i) ∈ \text{SE}(3)``
+and ``R_0 ∈ \text{SO}(3)`` such that ``R_0(T'_2-T'_1) = e_z``.
 """
 project(::EssentialManifold, ::Any, ::Any)
 
@@ -481,12 +481,12 @@ end
 @doc raw"""
     vert_proj(M::EssentialManifold, p, X)
 
-Project `X` onto the vertical space $T_{\text{vp}}\text{SO}(3)^2$ with
+Project `X` onto the vertical space ``T_{\text{vp}}\text{SO}(3)^2`` with
 ````math
 \text{vert\_proj}_p(X) = e_z^T(R_1 X_1 + R_2 X_2),
 ````
-where $e_z$ is the third unit vector, $X_i ∈ T_{p}\text{SO}(3)$ for $i=1,2,$ and it holds $R_i = R_0 R'_i, i=1,2,$ where $R'_i$ is part of the
-pose of camera ``i`` $g_i = (R_i,T'_i) ∈ \text{SE}(3)$ and $R_0 ∈ \text{SO}(3)$ such that $R_0(T'_2-T'_1) = e_z$ [TronDaniilidis:2017](@cite).
+where ``e_z`` is the third unit vector, ``X_i ∈ T_{p}\text{SO}(3)`` for ``i=1,2,`` and it holds ``R_i = R_0 R'_i, i=1,2,`` where ``R'_i`` is part of the
+pose of camera ``i`` ``g_i = (R_i,T'_i) ∈ \text{SE}(3)`` and ``R_0 ∈ \text{SO}(3)`` such that ``R_0(T'_2-T'_1) = e_z`` [TronDaniilidis:2017](@cite).
 """
 function vert_proj(M::EssentialManifold, p, X)
     return sum(vert_proj.(Ref(M.manifold), p, X))

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -1,16 +1,16 @@
 @doc raw"""
     Hyperbolic{T} <: AbstractDecoratorManifold{ℝ}
 
-The hyperbolic space $\mathcal H^n$ represented by $n+1$-Tuples, i.e. embedded in the
+The hyperbolic space ``\mathcal H^n`` represented by ``n+1``-Tuples, i.e. embedded in the
 [`Lorentz`](@ref)ian manifold equipped with the [`MinkowskiMetric`](@ref)
-$⟨⋅,⋅⟩_{\mathrm{M}}$. The space is defined as
+``⟨⋅,⋅⟩_{\mathrm{M}}``. The space is defined as
 
 ```math
 \mathcal H^n = \Bigl\{p ∈ ℝ^{n+1}\ \Big|\ ⟨p,p⟩_{\mathrm{M}}= -p_{n+1}^2
   + \displaystyle\sum_{k=1}^n p_k^2 = -1, p_{n+1} > 0\Bigr\},.
 ```
 
-The tangent space $T_p \mathcal H^n$ is given by
+The tangent space ``T_p \mathcal H^n`` is given by
 
 ````math
 T_p \mathcal H^n := \bigl\{
@@ -19,7 +19,7 @@ X ∈ ℝ^{n+1} : ⟨p,X⟩_{\mathrm{M}} = 0
 ````
 Note that while the [`MinkowskiMetric`](@ref) renders the [`Lorentz`](@ref) manifold (only)
 pseudo-Riemannian, on the tangent bundle of the Hyperbolic space it induces a Riemannian
-metric. The corresponding sectional curvature is $-1$.
+metric. The corresponding sectional curvature is ``-1``.
 
 If `p` and `X` are `Vector`s of length `n+1` they are assumed to be
 a [`HyperboloidPoint`](@ref) and a [`HyperboloidTVector`](@ref), respectively
@@ -49,8 +49,8 @@ end
 @doc raw"""
     HyperboloidPoint <: AbstractManifoldPoint
 
-In the Hyperboloid model of the [`Hyperbolic`](@ref) $\mathcal H^n$ points are represented
-as vectors in $ℝ^{n+1}$ with [`MinkowskiMetric`](@ref) equal to $-1$.
+In the Hyperboloid model of the [`Hyperbolic`](@ref) ``\mathcal H^n`` points are represented
+as vectors in ``ℝ^{n+1}`` with [`MinkowskiMetric`](@ref) equal to ``-1``.
 
 This representation is the default, i.e. `AbstractVector`s are assumed to have this repesentation.
 """
@@ -61,8 +61,8 @@ end
 @doc raw"""
     HyperboloidTVector <: TVector
 
-In the Hyperboloid model of the [`Hyperbolic`](@ref) $\mathcal H^n$ tangent vctors are represented
-as vectors in $ℝ^{n+1}$ with [`MinkowskiMetric`](@ref) $⟨p,X⟩_{\mathrm{M}}=0$ to their base
+In the Hyperboloid model of the [`Hyperbolic`](@ref) ``\mathcal H^n`` tangent vctors are represented
+as vectors in ``ℝ^{n+1}`` with [`MinkowskiMetric`](@ref) ``⟨p,X⟩_{\mathrm{M}}=0`` to their base
 point ``p``.
 
 This representation is the default, i.e. vectors are assumed to have this repesentation.
@@ -74,8 +74,8 @@ end
 @doc raw"""
     PoincareBallPoint <: AbstractManifoldPoint
 
-A point on the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ can be represented as a vector of norm
-less than one in $\mathbb R^n$.
+A point on the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` can be represented as a vector of norm
+less than one in ``\mathbb R^n``.
 """
 struct PoincareBallPoint{TValue<:AbstractVector} <: AbstractManifoldPoint
     value::TValue
@@ -84,8 +84,8 @@ end
 @doc raw"""
     PoincareBallTVector <: TVector
 
-In the Poincaré ball model of the [`Hyperbolic`](@ref) $\mathcal H^n$ tangent vectors are represented
-as vectors in $ℝ^{n}$.
+In the Poincaré ball model of the [`Hyperbolic`](@ref) ``\mathcal H^n`` tangent vectors are represented
+as vectors in ``ℝ^{n}``.
 """
 struct PoincareBallTVector{TValue<:AbstractVector} <: AbstractManifoldPoint
     value::TValue
@@ -94,8 +94,8 @@ end
 @doc raw"""
     PoincareHalfSpacePoint <: AbstractManifoldPoint
 
-A point on the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ can be represented as a vector in the
-half plane, i.e. $x ∈ ℝ^n$ with $x_d > 0$.
+A point on the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` can be represented as a vector in the
+half plane, i.e. ``x ∈ ℝ^n`` with ``x_d > 0``.
 """
 struct PoincareHalfSpacePoint{TValue<:AbstractVector} <: AbstractManifoldPoint
     value::TValue
@@ -104,8 +104,8 @@ end
 @doc raw"""
     PoincareHalfPlaneTVector <: TVector
 
-In the Poincaré half plane model of the [`Hyperbolic`](@ref) $\mathcal H^n$ tangent vectors are
-represented as vectors in $ℝ^{n}$.
+In the Poincaré half plane model of the [`Hyperbolic`](@ref) ``\mathcal H^n`` tangent vectors are
+represented as vectors in ``ℝ^{n}``.
 """
 struct PoincareHalfSpaceTVector{TValue<:AbstractVector} <: TVector
     value::TValue
@@ -145,14 +145,14 @@ end
 Check whether `p` is a valid point on the [`Hyperbolic`](@ref) `M`.
 
 For the [`HyperboloidPoint`](@ref) or plain vectors this means that, `p` is a vector of
-length $n+1$ with inner product in the embedding of -1, see [`MinkowskiMetric`](@ref).
+length ``n+1`` with inner product in the embedding of -1, see [`MinkowskiMetric`](@ref).
 The tolerance for the last test can be set using the `kwargs...`.
 
-For the [`PoincareBallPoint`](@ref) a valid point is a vector $p ∈ ℝ^n$ with a norm stricly
+For the [`PoincareBallPoint`](@ref) a valid point is a vector ``p ∈ ℝ^n`` with a norm stricly
 less than 1.
 
-For the [`PoincareHalfSpacePoint`](@ref) a valid point is a vector from $p ∈ ℝ^n$ with a positive
-last entry, i.e. $p_n>0$
+For the [`PoincareHalfSpacePoint`](@ref) a valid point is a vector from ``p ∈ ℝ^n`` with a positive
+last entry, i.e. ``p_n>0``
 """
 check_point(::Hyperbolic, ::Any)
 
@@ -166,7 +166,7 @@ The tolerance for the last test can be set using the `kwargs...`.
 For a the hyperboloid model or vectors, `X` has to be  orthogonal to `p` with respect
 to the inner product from the embedding, see [`MinkowskiMetric`](@ref).
 
-For a the Poincaré ball as well as the Poincaré half plane model, `X` has to be a vector from $ℝ^{n}$.
+For a the Poincaré ball as well as the Poincaré half plane model, `X` has to be a vector from ``ℝ^{n}``.
 """
 check_vector(::Hyperbolic, ::Any, ::Any)
 
@@ -215,7 +215,7 @@ embed(::Hyperbolic, p::AbstractArray, X::AbstractArray) = X
 @doc raw"""
     exp(M::Hyperbolic, p, X)
 
-Compute the exponential map on the [`Hyperbolic`](@ref) space $\mathcal H^n$ emanating
+Compute the exponential map on the [`Hyperbolic`](@ref) space ``\mathcal H^n`` emanating
 from `p` towards `X`. The formula reads
 
 ````math
@@ -223,7 +223,7 @@ from `p` towards `X`. The formula reads
 + \sinh(\sqrt{⟨X,X⟩_{\mathrm{M}}})\frac{X}{\sqrt{⟨X,X⟩_{\mathrm{M}}}},
 ````
 
-where $⟨⋅,⋅⟩_{\mathrm{M}}$ denotes the [`MinkowskiMetric`](@ref) on the embedding,
+where ``⟨⋅,⋅⟩_{\mathrm{M}}`` denotes the [`MinkowskiMetric`](@ref) on the embedding,
 the [`Lorentz`](@ref)ian manifold.
 """
 exp(::Hyperbolic, ::Any...)
@@ -278,17 +278,17 @@ is_flat(M::Hyperbolic) = false
 @doc raw"""
     log(M::Hyperbolic, p, q)
 
-Compute the logarithmic map on the [`Hyperbolic`](@ref) space $\mathcal H^n$, the tangent
+Compute the logarithmic map on the [`Hyperbolic`](@ref) space ``\mathcal H^n``, the tangent
 vector representing the [`geodesic`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/functions.html#ManifoldsBase.geodesic-Tuple{AbstractManifold,%20Any,%20Any}) starting from `p`
-reaches `q` after time 1. The formula reads for $p ≠ q$
+reaches `q` after time 1. The formula reads for ``p ≠ q``
 
 ```math
 \log_p q = d_{\mathcal H^n}(p,q)
 \frac{q-⟨p,q⟩_{\mathrm{M}} p}{\lVert q-⟨p,q⟩_{\mathrm{M}} p \rVert_2},
 ```
 
-where $⟨⋅,⋅⟩_{\mathrm{M}}$ denotes the [`MinkowskiMetric`](@ref) on the embedding,
-the [`Lorentz`](@ref)ian manifold. For $p=q$ the logarihmic map is equal to the zero vector.
+where ``⟨⋅,⋅⟩_{\mathrm{M}}`` denotes the [`MinkowskiMetric`](@ref) on the embedding,
+the [`Lorentz`](@ref)ian manifold. For ``p=q`` the logarihmic map is equal to the zero vector.
 """
 log(::Hyperbolic, ::Any...)
 
@@ -307,14 +307,14 @@ end
 @doc raw"""
     manifold_dimension(M::Hyperbolic)
 
-Return the dimension of the hyperbolic space manifold $\mathcal H^n$, i.e. $\dim(\mathcal H^n) = n$.
+Return the dimension of the hyperbolic space manifold ``\mathcal H^n``, i.e. ``\dim(\mathcal H^n) = n``.
 """
 manifold_dimension(M::Hyperbolic) = get_parameter(M.size)[1]
 
 @doc raw"""
     manifold_dimension(M::Hyperbolic)
 
-Return the volume of the hyperbolic space manifold $\mathcal H^n$, i.e. infinity.
+Return the volume of the hyperbolic space manifold ``\mathcal H^n``, i.e. infinity.
 """
 manifold_volume(::Hyperbolic) = Inf
 
@@ -344,7 +344,7 @@ The formula reads
 ````math
 Y = X + ⟨p,X⟩_{\mathrm{M}} p,
 ````
-where $⟨⋅, ⋅⟩_{\mathrm{M}}$ denotes the [`MinkowskiMetric`](@ref) on the embedding,
+where ``⟨⋅, ⋅⟩_{\mathrm{M}}`` denotes the [`MinkowskiMetric`](@ref) on the embedding,
 the [`Lorentz`](@ref)ian manifold.
 
 !!! note
@@ -369,14 +369,14 @@ end
     parallel_transport_to(M::Hyperbolic, p, X, q)
 
 Compute the paralllel transport of the `X` from the tangent space at `p` on the
-[`Hyperbolic`](@ref) space $\mathcal H^n$ to the tangent at `q` along the [`geodesic`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/functions.html#ManifoldsBase.geodesic-Tuple{AbstractManifold,%20Any,%20Any})
+[`Hyperbolic`](@ref) space ``\mathcal H^n`` to the tangent at `q` along the [`geodesic`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/functions.html#ManifoldsBase.geodesic-Tuple{AbstractManifold,%20Any,%20Any})
 connecting `p` and `q`. The formula reads
 
 ````math
 \mathcal P_{q←p}X = X - \frac{⟨\log_p q,X⟩_p}{d^2_{\mathcal H^n}(p,q)}
 \bigl(\log_p q + \log_qp \bigr),
 ````
-where $⟨⋅,⋅⟩_p$ denotes the inner product in the tangent space at `p`.
+where ``⟨⋅,⋅⟩_p`` denotes the inner product in the tangent space at `p`.
 """
 parallel_transport_to(::Hyperbolic, ::Any, ::Any, ::Any)
 

--- a/src/manifolds/HyperbolicHyperboloid.jl
+++ b/src/manifolds/HyperbolicHyperboloid.jl
@@ -79,8 +79,8 @@ convert(::Type{AbstractVector}, p::HyperboloidPoint) = p.value
     convert(::Type{HyperboloidPoint}, p::PoincareBallPoint)
     convert(::Type{AbstractVector}, p::PoincareBallPoint)
 
-convert a point [`PoincareBallPoint`](@ref) `x` (from $ℝ^n$) from the
-Poincaré ball model of the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ to a [`HyperboloidPoint`](@ref) $π(p) ∈ ℝ^{n+1}$.
+convert a point [`PoincareBallPoint`](@ref) `x` (from ``ℝ^n``) from the
+Poincaré ball model of the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` to a [`HyperboloidPoint`](@ref) ``π(p) ∈ ℝ^{n+1}``.
 The isometry is defined by
 
 ````math
@@ -101,8 +101,8 @@ end
     convert(::Type{HyperboloidPoint}, p::PoincareHalfSpacePoint)
     convert(::Type{AbstractVector}, p::PoincareHalfSpacePoint)
 
-convert a point [`PoincareHalfSpacePoint`](@ref) `p` (from $ℝ^n$) from the
-Poincaré half plane model of the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ to a [`HyperboloidPoint`](@ref) $π(p) ∈ ℝ^{n+1}$.
+convert a point [`PoincareHalfSpacePoint`](@ref) `p` (from ``ℝ^n``) from the
+Poincaré half plane model of the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` to a [`HyperboloidPoint`](@ref) ``π(p) ∈ ℝ^{n+1}``.
 
 This is done in two steps, namely transforming it to a Poincare ball point and from there further on to a Hyperboloid point.
 """
@@ -121,7 +121,7 @@ Convert the [`PoincareBallTVector`](@ref) `X` from the tangent space at `p` to a
 [`HyperboloidTVector`](@ref) by computing the push forward of the isometric map, cf.
 [`convert(::Type{HyperboloidPoint}, p::PoincareBallPoint)`](@ref).
 
-The push forward $π_*(p)$ maps from $ℝ^n$ to a subspace of $ℝ^{n+1}$, the formula reads
+The push forward ``π_*(p)`` maps from ``ℝ^n`` to a subspace of ``ℝ^{n+1}``, the formula reads
 
 ````math
 π_*(p)[X] = \begin{pmatrix}
@@ -173,9 +173,9 @@ end
     convert(::Type{HyperboloidTVector}, p::PoincareHalfSpacePoint, X::PoincareHalfSpaceTVector)
     convert(::Type{AbstractVector}, p::PoincareHalfSpacePoint, X::PoincareHalfSpaceTVector)
 
-convert a point [`PoincareHalfSpaceTVector`](@ref) `X` (from $ℝ^n$) at `p` from the
-Poincaré half plane model of the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ to a
-[`HyperboloidTVector`](@ref) $π(p) ∈ ℝ^{n+1}$.
+convert a point [`PoincareHalfSpaceTVector`](@ref) `X` (from ``ℝ^n``) at `p` from the
+Poincaré half plane model of the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` to a
+[`HyperboloidTVector`](@ref) ``π(p) ∈ ℝ^{n+1}``.
 
 This is done in two steps, namely transforming it to a Poincare ball point and from there further on to a Hyperboloid point.
 """
@@ -204,9 +204,9 @@ end
         (p,X)::Tuple{PoincareHalfSpacePoint, PoincareHalfSpaceTVector}
     ) where {T<:AbstractVector}
 
-convert a point [`PoincareHalfSpaceTVector`](@ref) `X` (from $ℝ^n$) at `p` from the
-Poincaré half plane model of the [`Hyperbolic`](@ref) manifold $\mathcal H^n$
-to a tuple of a [`HyperboloidPoint`](@ref) and a [`HyperboloidTVector`](@ref) $π(p) ∈ ℝ^{n+1}$
+convert a point [`PoincareHalfSpaceTVector`](@ref) `X` (from ``ℝ^n``) at `p` from the
+Poincaré half plane model of the [`Hyperbolic`](@ref) manifold ``\mathcal H^n``
+to a tuple of a [`HyperboloidPoint`](@ref) and a [`HyperboloidTVector`](@ref) ``π(p) ∈ ℝ^{n+1}``
 simultaneously.
 
 This is done in two steps, namely transforming it to the Poincare ball model and from there
@@ -229,7 +229,7 @@ Compute the distance on the [`Hyperbolic`](@ref) `M`, which reads
 d_{\mathcal H^n}(p,q) = \operatorname{acosh}( - ⟨p, q⟩_{\mathrm{M}}),
 ````
 
-where $⟨⋅,⋅⟩_{\mathrm{M}}$ denotes the [`MinkowskiMetric`](@ref) on the embedding,
+where ``⟨⋅,⋅⟩_{\mathrm{M}}`` denotes the [`MinkowskiMetric`](@ref) on the embedding,
 the [`Lorentz`](@ref)ian manifold.
 """
 function distance(::Hyperbolic, p, q)
@@ -308,7 +308,7 @@ end
     get_coordinates(M::Hyperbolic, p, X, ::DefaultOrthonormalBasis)
 
 Compute the coordinates of the vector `X` with respect to the orthogonalized version of
-the unit vectors from $ℝ^n$, where ``n`` is the manifold dimension of the [`Hyperbolic`](@ref)
+the unit vectors from ``ℝ^n``, where ``n`` is the manifold dimension of the [`Hyperbolic`](@ref)
  `M`, utting them intop the tangent space at `p` and orthonormalizing them.
 """
 get_coordinates(M::Hyperbolic, p, X, ::DefaultOrthonormalBasis)
@@ -335,7 +335,7 @@ end
     get_vector(M::Hyperbolic, p, c, ::DefaultOrthonormalBasis)
 
 Compute the vector from the coordinates with respect to the orthogonalized version of
-the unit vectors from $ℝ^n$, where ``n`` is the manifold dimension of the [`Hyperbolic`](@ref)
+the unit vectors from ``ℝ^n``, where ``n`` is the manifold dimension of the [`Hyperbolic`](@ref)
  `M`, utting them intop the tangent space at `p` and orthonormalizing them.
 """
 get_vector(M::Hyperbolic, p, c, ::DefaultOrthonormalBasis)
@@ -353,7 +353,7 @@ end
     _hyperbolize(M, q)
 
 Given the [`Hyperbolic`](@ref)`(n)` manifold using the hyperboloid model, a point from the
-$q\in ℝ^n$ can be set onto the manifold by computing its last component such that for the
+``q\in ℝ^n`` can be set onto the manifold by computing its last component such that for the
 resulting `p` we have that its [`minkowski_metric`](@ref) is ``⟨p,p⟩_{\mathrm{M}} = - 1``,
 i.e. ``p_{n+1} = \sqrt{\lVert q \rVert^2 - 1}``
 """
@@ -363,10 +363,10 @@ _hyperbolize(::Hyperbolic, q) = vcat(q, sqrt(norm(q)^2 + 1))
     _hyperbolize(M, p, Y)
 
 Given the [`Hyperbolic`](@ref)`(n)` manifold using the hyperboloid model and a point `p`
-thereon, we can put a vector $Y\in ℝ^n$  into the tangent space by computing its last
+thereon, we can put a vector ``Y\in ℝ^n``  into the tangent space by computing its last
 component such that for the
-resulting `p` we have that its [`minkowski_metric`](@ref) is $⟨p,X⟩_{\mathrm{M}} = 0$,
-i.e. $X_{n+1} = \frac{⟨\tilde p, Y⟩}{p_{n+1}}$, where $\tilde p = (p_1,\ldots,p_n)$.
+resulting `p` we have that its [`minkowski_metric`](@ref) is ``⟨p,X⟩_{\mathrm{M}} = 0``,
+i.e. ``X_{n+1} = \frac{⟨\tilde p, Y⟩}{p_{n+1}}``, where ``\tilde p = (p_1,\ldots,p_n)``.
 """
 _hyperbolize(::Hyperbolic, p, Y) = vcat(Y, dot(p[1:(end - 1)], Y) / p[end])
 

--- a/src/manifolds/HyperbolicPoincareBall.jl
+++ b/src/manifolds/HyperbolicPoincareBall.jl
@@ -77,8 +77,8 @@ end
     convert(::Type{PoincareBallPoint}, p::HyperboloidPoint)
     convert(::Type{PoincareBallPoint}, p::T) where {T<:AbstractVector}
 
-convert a [`HyperboloidPoint`](@ref) $p∈ℝ^{n+1}$ from the hyperboloid model of the [`Hyperbolic`](@ref)
-manifold $\mathcal H^n$ to a [`PoincareBallPoint`](@ref) $π(p)∈ℝ^{n}$ in the Poincaré ball model.
+convert a [`HyperboloidPoint`](@ref) ``p∈ℝ^{n+1}`` from the hyperboloid model of the [`Hyperbolic`](@ref)
+manifold ``\mathcal H^n`` to a [`PoincareBallPoint`](@ref) ``π(p)∈ℝ^{n}`` in the Poincaré ball model.
 The isometry is defined by
 
 ````math
@@ -98,9 +98,9 @@ end
 @doc raw"""
     convert(::Type{PoincareBallPoint}, p::PoincareHalfSpacePoint)
 
-convert a point [`PoincareHalfSpacePoint`](@ref) `p` (from $ℝ^n$) from the
-Poincaré half plane model of the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ to a [`PoincareBallPoint`](@ref) $π(p) ∈ ℝ^n$.
-Denote by $\tilde p = (p_1,\ldots,p_{d-1})^{\mathrm{T}}$. Then the isometry is defined by
+convert a point [`PoincareHalfSpacePoint`](@ref) `p` (from ``ℝ^n``) from the
+Poincaré half plane model of the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` to a [`PoincareBallPoint`](@ref) ``π(p) ∈ ℝ^n``.
+Denote by ``\tilde p = (p_1,\ldots,p_{d-1})^{\mathrm{T}}``. Then the isometry is defined by
 
 ````math
 π(p) = \frac{1}{\lVert \tilde p \rVert^2 + (p_n+1)^2}
@@ -119,7 +119,7 @@ end
     convert(::Type{PoincareBallTVector}, p::P, X::T) where {P<:AbstractVector, T<:AbstractVector}
 
 convert a [`HyperboloidTVector`](@ref) `X` at `p` to a [`PoincareBallTVector`](@ref)
-on the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ by computing the push forward $π_*(p)[X]$ of
+on the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` by computing the push forward ``π_*(p)[X]`` of
 the isometry ``π`` that maps from the Hyperboloid to the Poincaré ball,
 cf. [`convert(::Type{PoincareBallPoint}, ::HyperboloidPoint)`](@ref).
 
@@ -129,8 +129,8 @@ The formula reads
 π_*(p)[X] = \frac{1}{p_{n+1}+1}\Bigl(\tilde X - \frac{X_{n+1}}{p_{n+1}+1}\tilde p \Bigl),
 ````
 
-where $\tilde X = \begin{pmatrix}X_1\\⋮\\X_n\end{pmatrix}$
-and $\tilde p = \begin{pmatrix}p_1\\⋮\\p_n\end{pmatrix}$.
+where ``\tilde X = \begin{pmatrix}X_1\\⋮\\X_n\end{pmatrix}``
+and ``\tilde p = \begin{pmatrix}p_1\\⋮\\p_n\end{pmatrix}``.
 """
 convert(::Type{PoincareBallTVector}, ::Any)
 function convert(t::Type{PoincareBallTVector}, p::HyperboloidPoint, X::HyperboloidTVector)
@@ -183,7 +183,7 @@ end
     )
 
 convert a [`PoincareHalfSpaceTVector`](@ref) `X` at `p` to a [`PoincareBallTVector`](@ref)
-on the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ by computing the push forward $π_*(p)[X]$ of
+on the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` by computing the push forward ``π_*(p)[X]`` of
 the isometry ``π`` that maps from the Poincaré half space to the Poincaré ball,
 cf. [`convert(::Type{PoincareBallPoint}, ::PoincareHalfSpacePoint)`](@ref).
 
@@ -207,7 +207,7 @@ The formula reads
 (\lVert p \rVert^2-1)(⟨X,p⟩+X_n)
 \end{pmatrix}
 ````
-where $\tilde p = \begin{pmatrix}p_1\\⋮\\p_{n-1}\end{pmatrix}$.
+where ``\tilde p = \begin{pmatrix}p_1\\⋮\\p_{n-1}\end{pmatrix}``.
 """
 function convert(
     ::Type{PoincareBallTVector},
@@ -249,7 +249,7 @@ end
 @doc raw"""
     distance(::Hyperbolic, p::PoincareBallPoint, q::PoincareBallPoint)
 
-Compute the distance on the [`Hyperbolic`](@ref) manifold $\mathcal H^n$ represented in the
+Compute the distance on the [`Hyperbolic`](@ref) manifold ``\mathcal H^n`` represented in the
 Poincaré ball model. The formula reads
 
 ````math
@@ -304,7 +304,7 @@ end
     project(::Hyperbolic, ::PoincareBallPoint, ::PoincareBallTVector)
 
 projction of tangent vectors in the Poincaré ball model is just the identity, since
-the tangent space consists of all $ℝ^n$.
+the tangent space consists of all ``ℝ^n``.
 """
 project(::Hyperbolic, ::PoincareBallPoint, ::PoincareBallTVector)
 

--- a/src/manifolds/Spectrahedron.jl
+++ b/src/manifolds/Spectrahedron.jl
@@ -16,13 +16,13 @@ positive semidefinite matrices) of rank ``k`` with unit trace.
 ````
 
 This manifold is working solely on the matrices ``q``. Note that this ``q`` is not unique,
-indeed for any orthogonal matrix ``A`` we have $(qA)(qA)^{\mathrm{T}} = qq^{\mathrm{T}} = p$,
+indeed for any orthogonal matrix ``A`` we have ``(qA)(qA)^{\mathrm{T}} = qq^{\mathrm{T}} = p``,
 so the manifold implemented here is the quotient manifold. The unit trace translates to
 unit frobenius norm of ``q``.
 
 
-The tangent space at ``p``, denoted $T_p\mathcal E(n,k)$, is also represented by matrices
-$Y\in ℝ^{n×k}$ and reads as
+The tangent space at ``p``, denoted ``T_p\mathcal E(n,k)``, is also represented by matrices
+``Y\in ℝ^{n×k}`` and reads as
 
 ````math
 T_p\mathcal S(n,k) = \bigl\{
@@ -30,7 +30,7 @@ X ∈ ℝ^{n×n}\,|\,X = qY^{\mathrm{T}} + Yq^{\mathrm{T}}
 \text{ with } \operatorname{tr}(X) = \sum_{i=1}^{n}X_{ii} = 0
 \bigr\}
 ````
-endowed with the [`Euclidean`](@ref) metric from the embedding, i.e. from the $ℝ^{n×k}$
+endowed with the [`Euclidean`](@ref) metric from the embedding, i.e. from the ``ℝ^{n×k}``
 
 
 This manifold was for example
@@ -40,7 +40,7 @@ investigated in [JourneeBachAbsilSepulchre:2010](@cite).
 
     Spectrahedron(n::Int, k::Int; parameter::Symbol=:type)
 
-generates the manifold $\mathcal S(n,k) \subset ℝ^{n×n}$.
+generates the manifold ``\mathcal S(n,k) \subset ℝ^{n×n}``.
 """
 struct Spectrahedron{T} <: AbstractDecoratorManifold{ℝ}
     size::T
@@ -56,7 +56,7 @@ active_traits(f, ::Spectrahedron, args...) = merge_traits(IsIsometricEmbeddedMan
 @doc raw"""
     check_point(M::Spectrahedron, q; kwargs...)
 
-checks, whether `q` is a valid reprsentation of a point $p=qq^{\mathrm{T}}$ on the
+checks, whether `q` is a valid reprsentation of a point ``p=qq^{\mathrm{T}}`` on the
 [`Spectrahedron`](@ref) `M`, i.e. is a matrix
 of size `(N,K)`, such that ``p`` is symmetric positive semidefinite and has unit trace,
 i.e. ``q`` has to have unit frobenius norm.
@@ -78,8 +78,8 @@ end
 @doc raw"""
     check_vector(M::Spectrahedron, q, Y; kwargs...)
 
-Check whether $X = qY^{\mathrm{T}} + Yq^{\mathrm{T}}$ is a tangent vector to
-$p=qq^{\mathrm{T}}$ on the [`Spectrahedron`](@ref) `M`,
+Check whether ``X = qY^{\mathrm{T}} + Yq^{\mathrm{T}}`` is a tangent vector to
+``p=qq^{\mathrm{T}}`` on the [`Spectrahedron`](@ref) `M`,
 i.e. atfer [`check_point`](@ref) of `q`, `Y` has to be of same dimension as `q`
 and a ``X`` has to be a symmetric matrix with trace.
 The tolerance for the base point check and zero diagonal can be set using the `kwargs...`.
@@ -122,7 +122,7 @@ is_flat(M::Spectrahedron) = false
     manifold_dimension(M::Spectrahedron)
 
 returns the dimension of
-[`Spectrahedron`](@ref) `M`$=\mathcal S(n,k), n,k ∈ ℕ$, i.e.
+[`Spectrahedron`](@ref) `M```=\mathcal S(n,k), n,k ∈ ℕ``, i.e.
 ````math
 \dim \mathcal S(n,k) = nk - 1 - \frac{k(k-1)}{2}.
 ````
@@ -158,7 +158,7 @@ end
 @doc raw"""
     retract(M::Spectrahedron, q, Y, ::ProjectionRetraction)
 
-compute a projection based retraction by projecting $q+Y$ back onto the manifold.
+compute a projection based retraction by projecting ``q+Y`` back onto the manifold.
 """
 retract(::Spectrahedron, ::Any, ::Any, ::ProjectionRetraction)
 
@@ -168,8 +168,8 @@ retract_project!(M::Spectrahedron, r, q, Y, t::Number) = project!(M, r, q .+ t .
     representation_size(M::Spectrahedron)
 
 Return the size of an array representing an element on the
-[`Spectrahedron`](@ref) manifold `M`, i.e. $n×k$, the size of such factor of $p=qq^{\mathrm{T}}$
-on $\mathcal M = \mathcal S(n,k)$.
+[`Spectrahedron`](@ref) manifold `M`, i.e. ``n×k``, the size of such factor of ``p=qq^{\mathrm{T}}``
+on ``\mathcal M = \mathcal S(n,k)``.
 """
 representation_size(M::Spectrahedron) = get_parameter(M.size)
 

--- a/src/manifolds/SymmetricPositiveDefiniteAffineInvariant.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteAffineInvariant.jl
@@ -64,8 +64,8 @@ as a [`MetricManifold`](@ref) with [`AffineInvariantMetric`](@ref). The formula 
 d_{\mathcal P(n)}(p,q)
 = \lVert \operatorname{Log}(p^{-\frac{1}{2}}qp^{-\frac{1}{2}})\rVert_{\mathrm{F}}.,
 ```
-where $\operatorname{Log}$ denotes the matrix logarithm and
-$\lVert⋅\rVert_{\mathrm{F}}$ denotes the matrix Frobenius norm.
+where ``\operatorname{Log}`` denotes the matrix logarithm and
+``\lVert⋅\rVert_{\mathrm{F}}`` denotes the matrix Frobenius norm.
 """
 function distance(::SymmetricPositiveDefinite, p, q)
     # avoid numerical instabilities in cholesky
@@ -90,7 +90,7 @@ Compute the exponential map from `p` with tangent vector `X` on the
 \exp_p X = p^{\frac{1}{2}}\operatorname{Exp}(p^{-\frac{1}{2}} X p^{-\frac{1}{2}})p^{\frac{1}{2}},
 ```
 
-where $\operatorname{Exp}$ denotes to the matrix exponential.
+where ``\operatorname{Exp}`` denotes to the matrix exponential.
 """
 exp(::SymmetricPositiveDefinite, ::Any...)
 
@@ -151,7 +151,7 @@ end
 Return a orthonormal basis `Ξ` as a vector of tangent vectors (of length
 [`manifold_dimension`](@ref) of `M`) in the tangent space of `p` on the
 [`MetricManifold`](@ref) of [`SymmetricPositiveDefinite`](@ref) manifold `M` with
-[`AffineInvariantMetric`](@ref) that diagonalizes the curvature tensor $R(u,v)w$
+[`AffineInvariantMetric`](@ref) that diagonalizes the curvature tensor ``R(u,v)w``
 with eigenvalues `κ` and where the direction `B.frame_direction` ``V`` has curvature `0`.
 
 The construction is based on an ONB for the symmetric matrices similar to [`get_basis(::SymmetricPositiveDefinite, p, ::DefaultOrthonormalBasis`](@ref  get_basis(M::SymmetricPositiveDefinite,p,B::DefaultOrthonormalBasis{<:Any,ManifoldsBase.TangentSpaceType}))
@@ -234,7 +234,7 @@ the coordinates with respect to this ONB can be simplified to
 ```math
    c_k = \mathrm{tr}(p^{-\frac{1}{2}}\Delta_{i,j} X)
 ```
-where ``k`` is trhe linearized index of the $i=1,\ldots,n, j=i,\ldots,n$.
+where ``k`` is trhe linearized index of the ``i=1,\ldots,n, j=i,\ldots,n``.
 """
 get_coordinates(::SymmetricPositiveDefinite, c, p, X, ::DefaultOrthonormalBasis)
 
@@ -272,7 +272,7 @@ the vector reconstruction with respect to this ONB can be simplified to
 ```math
    X = p^{\frac{1}{2}} \Biggl( \sum_{i=1,j=i}^n c_k \Delta_{i,j} \Biggr) p^{\frac{1}{2}}
 ```
-where ``k`` is the linearized index of the $i=1,\ldots,n, j=i,\ldots,n$.
+where ``k`` is the linearized index of the ``i=1,\ldots,n, j=i,\ldots,n``.
 """
 get_vector(::SymmetricPositiveDefinite, X, p, c, ::DefaultOrthonormalBasis)
 
@@ -334,7 +334,7 @@ as a [`MetricManifold`](@ref) with [`AffineInvariantMetric`](@ref). The formula 
 \log_p q =
 p^{\frac{1}{2}}\operatorname{Log}(p^{-\frac{1}{2}}qp^{-\frac{1}{2}})p^{\frac{1}{2}},
 ```
-where $\operatorname{Log}$ denotes to the matrix logarithm.
+where ``\operatorname{Log}`` denotes to the matrix logarithm.
 """
 log(::SymmetricPositiveDefinite, ::Any...)
 
@@ -384,7 +384,7 @@ p^{-\frac{1}{2}}X p^{-\frac{1}{2}}
 p^{\frac{1}{2}},
 ```
 
-where $\operatorname{Exp}$ denotes the matrix exponential
+where ``\operatorname{Exp}`` denotes the matrix exponential
 and `log` the logarithmic map on [`SymmetricPositiveDefinite`](@ref)
 (again with respect to the [`AffineInvariantMetric`](@ref)).
 """

--- a/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
+++ b/src/manifolds/SymmetricPositiveDefiniteLogCholesky.jl
@@ -32,8 +32,8 @@ d_{\mathcal P(n)}(p,q) = \sqrt{
 ````
 
 where ``x`` and ``y`` are the cholesky factors of ``p`` and ``q``, respectively,
-$⌊⋅⌋$ denbotes the strictly lower triangular matrix of its argument,
-and $\lVert⋅\rVert_{\mathrm{F}}$ the Frobenius norm.
+``⌊⋅⌋`` denbotes the strictly lower triangular matrix of its argument,
+and ``\lVert⋅\rVert_{\mathrm{F}}`` the Frobenius norm.
 """
 function distance(M::MetricManifold{ℝ,<:SymmetricPositiveDefinite,LogCholeskyMetric}, p, q)
     N = get_parameter(M.manifold.size)[1]
@@ -50,10 +50,10 @@ Compute the exponential map on the [`SymmetricPositiveDefinite`](@ref) `M` with
 \exp_p X = (\exp_y W)(\exp_y W)^\mathrm{T}
 ````
 
-where $\exp_xW$ is the exponential map on [`CholeskySpace`](@ref), ``y`` is the cholesky
-decomposition of ``p``, $W = y(y^{-1}Xy^{-\mathrm{T}})_\frac{1}{2}$,
-and $(⋅)_\frac{1}{2}$
-denotes the lower triangular matrix with the diagonal multiplied by $\frac{1}{2}$.
+where ``\exp_xW`` is the exponential map on [`CholeskySpace`](@ref), ``y`` is the cholesky
+decomposition of ``p``, ``W = y(y^{-1}Xy^{-\mathrm{T}})_\frac{1}{2}``,
+and ``(⋅)_\frac{1}{2}``
+denotes the lower triangular matrix with the diagonal multiplied by ``\frac{1}{2}``.
 """
 exp(::MetricManifold{ℝ,SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
 
@@ -84,10 +84,10 @@ a [`MetricManifold`](@ref) with [`LogCholeskyMetric`](@ref). The formula reads
     g_p(X,Y) = ⟨a_z(X),a_z(Y)⟩_z,
 ````
 
-where $⟨⋅,⋅⟩_x$ denotes inner product on the [`CholeskySpace`](@ref),
+where ``⟨⋅,⋅⟩_x`` denotes inner product on the [`CholeskySpace`](@ref),
 ``z`` is the cholesky factor of ``p``,
-$a_z(W) = z (z^{-1}Wz^{-\mathrm{T}})_{\frac{1}{2}}$, and $(⋅)_\frac{1}{2}$
-denotes the lower triangular matrix with the diagonal multiplied by $\frac{1}{2}$
+``a_z(W) = z (z^{-1}Wz^{-\mathrm{T}})_{\frac{1}{2}}``, and ``(⋅)_\frac{1}{2}``
+denotes the lower triangular matrix with the diagonal multiplied by ``\frac{1}{2}``
 """
 function inner(M::MetricManifold{ℝ,<:SymmetricPositiveDefinite,LogCholeskyMetric}, p, X, Y)
     N = get_parameter(M.manifold.size)[1]
@@ -113,7 +113,7 @@ The formula can be adapted from the [`CholeskySpace`](@ref) as
 ````math
 \log_p q = xW^{\mathrm{T}} + Wx^{\mathrm{T}},
 ````
-where ``x`` is the cholesky factor of ``p`` and $W=\log_x y$ for ``y`` the cholesky factor
+where ``x`` is the cholesky factor of ``p`` and ``W=\log_x y`` for ``y`` the cholesky factor
 of ``q`` and the just mentioned logarithmic map is the one on [`CholeskySpace`](@ref).
 """
 log(::MetricManifold{ℝ,SymmetricPositiveDefinite,LogCholeskyMetric}, ::Any...)
@@ -139,8 +139,8 @@ Parallel transport the tangent vector `X` at `p` along the geodesic to `q` with 
 the [`SymmetricPositiveDefinite`](@ref) manifold `M` and [`LogCholeskyMetric`](@ref).
 The parallel transport is based on the parallel transport on [`CholeskySpace`](@ref):
 Let ``x`` and ``y`` denote the cholesky factors of `p` and `q`, respectively and
-$W = x(x^{-1}Xx^{-\mathrm{T}})_\frac{1}{2}$, where $(⋅)_\frac{1}{2}$ denotes the lower
-triangular matrix with the diagonal multiplied by $\frac{1}{2}$. With ``V`` the parallel
+``W = x(x^{-1}Xx^{-\mathrm{T}})_\frac{1}{2}``, where ``(⋅)_\frac{1}{2}`` denotes the lower
+triangular matrix with the diagonal multiplied by ``\frac{1}{2}``. With ``V`` the parallel
 transport on [`CholeskySpace`](@ref) from ``x`` to ``y``. The formula hear reads
 
 ````math

--- a/src/manifolds/Symplectic.jl
+++ b/src/manifolds/Symplectic.jl
@@ -218,7 +218,7 @@ end
 
 Check whether `p` is a valid point on the [`SymplecticMatrices`](@ref) `M`=$\mathrm{Sp}(2n)$,
 i.e. that it has the right [`AbstractNumbers`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/types.html#number-system) type and ``p^{+}p`` is (approximately)
-the identity, where ``A^+`` denotes the [`symplectic_inverse`]/@ref).
+the identity, where ``A^+`` denotes the [`symplectic_inverse`](@ref).
 
 The tolerance can be set with `kwargs...`.
 """
@@ -284,17 +284,20 @@ Compute an approximate geodesic distance between two Symplectic matrices
 
 ````math
   \operatorname{dist}(p, q)
-    ≈ \lVert\operatorname{Log}(p^+q)\rVert_{\\mathrm{Fr}},
+    ≈ \lVert\operatorname{Log}(p^+q)\rVert_{\mathrm{Fr}},
 ````
 where the ``\operatorname{Log}(⋅)`` operator is the matrix logarithm.
 
 This approximation is justified by first recalling the Baker-Campbell-Hausdorf formula,
+
 ````math
 \operatorname{Log}(\operatorname{Exp}(A)\operatorname{Exp}(B))
  = A + B + \frac{1}{2}[A, B] + \frac{1}{12}[A, [A, B]] + \frac{1}{12}[B, [B, A]]
     + \ldots \;.
 ````
+
 Then we write the expression for the exponential map from ``p`` to ``q`` as
+
 ````math
     q =
     \operatorname{exp}_p(X)
@@ -303,23 +306,29 @@ Then we write the expression for the exponential map from ``p`` to ``q`` as
     \operatorname{Exp}([p^{+}X - (p^{+}X)^{\mathrm{T}}]),
     X \in T_p\mathrm{Sp},
 ````
+
 and with the geodesic distance between ``p`` and ``q`` given by
-``\operatorname{dist}(p, q) = \lVertX\rVert_p = \lVertp^+X\rVert_{\\mathrm{Fr}}``
+
+```math
+\operatorname{dist}(p, q) = \lVert X \rVert_p = \lVert p^+ X \rVert_{\mathrm{Fr}}
+```
+
 we see that
-````math
-    \begin{align*}
-   \lVert\operatorname{Log}(p^+q)\rVert_{\\mathrm{Fr}}
+
+```math
+  \begin{align*}
+   \lVert\operatorname{Log}(p^+q)\rVert_{\mathrm{Fr}}
     &=\Bigl\lVert
         \operatorname{Log}\bigl(
             \operatorname{Exp}((p^{+}X)^{\mathrm{T}})
             \operatorname{Exp}(p^{+}X - (p^{+}X)^{\mathrm{T}})
         \bigr)
-    \Bigr\rVert_{\\mathrm{Fr}} \\
-    &=\lVertp^{+}X + \frac{1}{2}[(p^{+}X)^{\mathrm{T}}, p^{+}X - (p^{+}X)^{\mathrm{T}}]
-            + \ldots\lVert_{\\mathrm{Fr}} \\
-    &≈\lVertp^{+}X\rVert_{\\mathrm{Fr}} = \operatorname{dist}(p, q).
-    \end{align*}
-````
+    \Bigr\rVert_{\mathrm{Fr}} \\
+    &=\lVert p^{+}X + \frac{1}{2}[(p^{+}X)^{\mathrm{T}}, p^{+}X - (p^{+}X)^{\mathrm{T}}]
+        + \ldots\lVert_{\mathrm{Fr}} \\
+    &≈\lVert p^{+}X\rVert_{\mathrm{Fr}} = \operatorname{dist}(p, q).
+  \end{align*}
+```
 """
 function distance(M::SymplecticMatrices, p, q)
     return norm(log(symplectic_inverse_times(M, p, q)))

--- a/src/manifolds/SymplecticStiefel.jl
+++ b/src/manifolds/SymplecticStiefel.jl
@@ -23,7 +23,7 @@ The symplectic Stiefel tangent space at ``p`` can be parametrized as [BendokatZi
     &= \{X ∈ ℝ^{2n×2k} ∣ p^{T}J_{2n}X + X^{T}J_{2n}p = 0 \}, \\
     &= \{X = pΩ + p^sB \mid
         Ω ∈ ℝ^{2k×2k}, Ω^+ = -Ω, \\
-        &\qquad & p^s ∈ \mathrm{SpSt}(2n, 2(n- k)), B ∈ ℝ^{2(n-k)×2k}, \},
+        &\quad\qquad p^s ∈ \mathrm{SpSt}(2n, 2(n- k)), B ∈ ℝ^{2(n-k)×2k}, \},
 \end{align*}
 ```
 
@@ -452,9 +452,9 @@ That is, we find the element ``X ∈ T_p\mathrm{SpSt}(2n, 2k)``
 which solves the constrained optimization problem
 
 ````math
-    \operatorname{min}_{X ∈ ℝ^{2n×2k}} \frac{1}{2}||X - A||^2, \quad
+    \displazstyle\operatorname{min}_{X ∈ ℝ^{2n×2k}} \frac{1}{2}||X - A||^2, \quad
     \text{s.t.}\;
-    h(X)\colon= X^{\mathrm{T}} J p + p^{\mathrm{T}} J X = 0,
+    h(X) := X^{\mathrm{T}} J p + p^{\mathrm{T}} J X = 0,
 ````
 where ``h : ℝ^{2n×2k} → \operatorname{skew}(2k)`` defines
 the restriction of ``X`` onto the tangent space ``T_p\mathrm{SpSt}(2n, 2k)``.

--- a/src/statistics.jl
+++ b/src/statistics.jl
@@ -83,7 +83,7 @@ Compute the (optionally weighted) Riemannian center of mass also known as
 Karcher mean of the vector `x` of points on the [`AbstractManifold`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/types.html#ManifoldsBase.AbstractManifold)  `M`, defined
 as the point that satisfies the minimizer
 ````math
-\argmin_{y ∈ \mathcal M} \frac{1}{2 \sum_{i=1}^n w_i} \sum_{i=1}^n w_i\mathrm{d}_{\mathcal M}^2(y,x_i),
+\operatorname{argmin}_{y ∈ \mathcal M} \frac{1}{2 \sum_{i=1}^n w_i} \sum_{i=1}^n w_i\mathrm{d}_{\mathcal M}^2(y,x_i),
 ````
 where ``\mathrm{d}_{\mathcal M}`` denotes the Riemannian [`distance`](@ref).
 
@@ -443,7 +443,7 @@ end;
 Compute the (optionally weighted) Riemannian median of the vector `x` of points on the
 [`AbstractManifold`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/types.html#ManifoldsBase.AbstractManifold)  `M`, defined as the point that satisfies the minimizer
 ````math
-\argmin_{y ∈ \mathcal M} \frac{1}{\sum_{i=1}^n w_i} \sum_{i=1}^n w_i\mathrm{d}_{\mathcal M}(y,x_i),
+\operatorname{argmin}_{y ∈ \mathcal M} \frac{1}{\sum_{i=1}^n w_i} \sum_{i=1}^n w_i\mathrm{d}_{\mathcal M}(y,x_i),
 ````
 where ``\mathrm{d}_{\mathcal M}`` denotes the Riemannian [`distance`](@ref).
 This function is nonsmooth (i.e nondifferentiable).


### PR DESCRIPTION
This fixes a few math related typos in the docs and continues to use two backticks in Documenter Markdown and Julia Docstrings instead of `$`.

I propose to not make this a new version per se but leave it on master until a feature justifies registering a new 0.9.15 version. This PR still already mentions the two above fixes in the `NEWS.md`