### PR TITLE
GroupManifold accepts two arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.2] - unreleased
 
+### Added
+
+* `GroupManifold` can now be called with two arguments, the third one defaulting to `LeftInvariantRepresentation`.
+
 ### Changed
 
 * fixes a few typographical errors.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.1"
+version = "0.10.2"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -28,11 +28,8 @@ struct GroupManifold{
     vectors::VR
 end
 
-function GroupManifold(
-    M::AbstractManifold{𝔽},
-    op::AbstractGroupOperation,
-    rep::AbstractGroupVectorRepresentation=LeftInvariantRepresentation(),
-) where {𝔽}
+function GroupManifold(M::AbstractManifold{𝔽}, op::AbstractGroupOperation) where {𝔽}
+    rep = LeftInvariantRepresentation()
     return GroupManifold{𝔽,typeof(M),typeof(op),typeof(rep)}(M, op, rep)
 end
 

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -24,6 +24,14 @@ struct GroupManifold{
     vectors::VR
 end
 
+function GroupManifold(
+    M::AbstractManifold{𝔽},
+    op,
+    rep=LeftInvariantRepresentation(),
+) where {𝔽}
+    return GroupManifold{𝔽,typeof(M),typeof(op),typeof(rep)}(M, op, rep)
+end
+
 """
     vector_representation(M::GroupManifold)
 

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -8,7 +8,11 @@ Group manifolds by default forward metric-related operations to the wrapped mani
 
 # Constructor
 
-    GroupManifold(manifold, op)
+    GroupManifold(
+        manifold::AbstractManifold,
+        op::AbstractGroupOperation,
+        vectors::AbstractGroupVectorRepresentation=LeftInvariantRepresentation(),
+    )
 
 Define the group operation `op` acting on the manifold `manifold`, hence if `op` acts smoothly,
 this forms a Lie group.

--- a/src/groups/GroupManifold.jl
+++ b/src/groups/GroupManifold.jl
@@ -26,8 +26,8 @@ end
 
 function GroupManifold(
     M::AbstractManifold{𝔽},
-    op,
-    rep=LeftInvariantRepresentation(),
+    op::AbstractGroupOperation,
+    rep::AbstractGroupVectorRepresentation=LeftInvariantRepresentation(),
 ) where {𝔽}
     return GroupManifold{𝔽,typeof(M),typeof(op),typeof(rep)}(M, op, rep)
 end

--- a/test/groups/groups_general.jl
+++ b/test/groups/groups_general.jl
@@ -138,11 +138,7 @@ using Manifolds:
         @test switch_direction(LeftAction()) === RightAction()
         @test switch_direction(RightAction()) === LeftAction()
 
-        G = GroupManifold(
-            NotImplementedManifold(),
-            NotImplementedOperation(),
-            Manifolds.LeftInvariantRepresentation(),
-        )
+        G = GroupManifold(NotImplementedManifold(), NotImplementedOperation())
         @test Manifolds._action_order(G, 1, 2, LeftForwardAction()) === (1, 2)
         @test Manifolds._action_order(G, 1, 2, RightBackwardAction()) === (2, 1)
     end
@@ -153,11 +149,7 @@ using Manifolds:
     end
 
     @testset "Addition operation" begin
-        G = GroupManifold(
-            NotImplementedManifold(),
-            Manifolds.AdditionOperation(),
-            Manifolds.LeftInvariantRepresentation(),
-        )
+        G = GroupManifold(NotImplementedManifold(), Manifolds.AdditionOperation())
         test_group(
             G,
             [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],


### PR DESCRIPTION
The default representation for GroupManifold is `LeftInvariantRepresentation`, this ensures backward compatibility with previous versions of `Manifolds.jl`