### PR TITLE
Lie bracket is zero on so(2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Union type `MatrixGroup`
 - Columnwise group action with arbitrary matrix groups
 - `uniform_distribution` now has an error hint explaining what has to be done to make it work.
+- `lie_bracket` is exactly zero on orthogonal Lie algebra in 2D
 
 ## [0.10.3] - 2024-10-04
 

--- a/src/groups/general_unitary_groups.jl
+++ b/src/groups/general_unitary_groups.jl
@@ -349,8 +349,21 @@ function adjoint_action!(G::GeneralUnitaryMultiplicationGroup, Y, p, X, ::RightA
     return copyto!(G, Y, inv(G, p) * X * p)
 end
 
-Manifolds.lie_bracket(G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}}, ℝ}, ::Any, ::Any) = zeros(2,2)
-Manifolds.lie_bracket!(G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}}, ℝ}, X, ::Any, ::Any) = copyto!(X, zeros(2,2))
+function Manifolds.lie_bracket(
+    G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}},ℝ},
+    ::Any,
+    ::Any,
+)
+    return zeros(2, 2)
+end
+function Manifolds.lie_bracket!(
+    G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}},ℝ},
+    X,
+    ::Any,
+    ::Any,
+)
+    return copyto!(X, zeros(2, 2))
+end
 
 function volume_density(M::GeneralUnitaryMultiplicationGroup, p, X)
     return volume_density(M.manifold, p, X)

--- a/src/groups/general_unitary_groups.jl
+++ b/src/groups/general_unitary_groups.jl
@@ -351,10 +351,10 @@ end
 
 function Manifolds.lie_bracket(
     G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}},ℝ},
-    ::Any,
+    X,
     ::Any,
 )
-    return zeros(2, 2)
+    return zero(X)
 end
 function Manifolds.lie_bracket!(
     G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}},ℝ},
@@ -362,7 +362,7 @@ function Manifolds.lie_bracket!(
     ::Any,
     ::Any,
 )
-    return copyto!(X, zeros(2, 2))
+    return fill!(X, 0)
 end
 
 function volume_density(M::GeneralUnitaryMultiplicationGroup, p, X)

--- a/src/groups/general_unitary_groups.jl
+++ b/src/groups/general_unitary_groups.jl
@@ -349,6 +349,9 @@ function adjoint_action!(G::GeneralUnitaryMultiplicationGroup, Y, p, X, ::RightA
     return copyto!(G, Y, inv(G, p) * X * p)
 end
 
+Manifolds.lie_bracket(G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}}, ℝ}, ::Any, ::Any) = zeros(2,2)
+Manifolds.lie_bracket!(G::Manifolds.GeneralUnitaryMultiplicationGroup{ManifoldsBase.TypeParameter{Tuple{2}}, ℝ}, X, ::Any, ::Any) = copyto!(X, zeros(2,2))
+
 function volume_density(M::GeneralUnitaryMultiplicationGroup, p, X)
     return volume_density(M.manifold, p, X)
 end

--- a/test/groups/general_unitary_groups.jl
+++ b/test/groups/general_unitary_groups.jl
@@ -49,10 +49,10 @@ include("group_utils.jl")
         @testset "SO(2) Lie Bracket == 0" begin
             Y = [0.0 0.7071067811865475; -0.7071067811865475 0.0]
             X_ = copy(X)
-            X_[1,2] += 1e-16
+            X_[1, 2] += 1e-16
             @test is_vector(M, identity_element(M), X_)
-            @test lie_bracket(M, X_, Y) == zeros(2,2)
-            @test lie_bracket!(M, similar(X_), X_, Y) == zeros(2,2)
+            @test lie_bracket(M, X_, Y) == zeros(2, 2)
+            @test lie_bracket!(M, similar(X_), X_, Y) == zeros(2, 2)
         end
 
         M = SpecialOrthogonal(3)

--- a/test/groups/general_unitary_groups.jl
+++ b/test/groups/general_unitary_groups.jl
@@ -46,6 +46,15 @@ include("group_utils.jl")
         X = [0.0 -0.7071067811865475; 0.7071067811865475 0.0]
         @test volume_density(M, p, X) ≈ 1.0
 
+        @testset "SO(2) Lie Bracket == 0" begin
+            Y = [0.0 0.7071067811865475; -0.7071067811865475 0.0]
+            X_ = copy(X)
+            X_[1,2] += 1e-16
+            @test is_vector(M, identity_element(M), X_)
+            @test lie_bracket(M, X_, Y) == zeros(2,2)
+            @test lie_bracket!(M, similar(X_), X_, Y) == zeros(2,2)
+        end
+
         M = SpecialOrthogonal(3)
         p = [
             -0.5908399013383766 -0.6241917041179139 0.5111681988316876


### PR DESCRIPTION
After some computations, there are numerical errors in the elements of $`\mathfrak{so}(2)`$. This PR ensures that even after errors, the Lie bracket is exactly zero.