### PR TITLE
Add some type annotations in `GeneralUnitaryMatrices` `get_vector`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.8] – unreleased
+
+### Changed
+
+Some methods related to `get_vector` for `GeneralUnitaryMatrices` now have `AbstractVector` upper bound for coefficients.
+
 ## [0.10.7] – 2024-11-16
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/manifolds/GeneralUnitaryMatrices.jl
+++ b/src/manifolds/GeneralUnitaryMatrices.jl
@@ -518,7 +518,7 @@ function get_vector_orthogonal!(
     M::GeneralUnitaryMatrices{TypeParameter{Tuple{2}},ℝ},
     X,
     p,
-    Xⁱ,
+    Xⁱ::AbstractVector,
     N::RealNumbers,
 )
     return get_vector_orthogonal!(M, X, p, Xⁱ[1], N)
@@ -543,7 +543,7 @@ function get_vector_orthogonal!(
     M::GeneralUnitaryMatrices{TypeParameter{Tuple{n}},ℝ},
     X,
     p,
-    Xⁱ,
+    Xⁱ::AbstractVector,
     ::RealNumbers,
 ) where {n}
     @assert size(X) == (n, n)
@@ -622,7 +622,7 @@ function get_vector_orthonormal!(
     M::GeneralUnitaryMatrices{<:Any,ℝ},
     X,
     p,
-    Xⁱ,
+    Xⁱ::AbstractVector,
     N::RealNumbers,
 )
     T = Base.promote_eltype(p, X)


### PR DESCRIPTION
I had a nasty infinite recursion due to lack of an upper bound for that type. This didn't exactly solve the recursion but at least it was a less bad one with a useful stack trace.