### PR TITLE
`get_vector` on `Circle` no longer returns `SArray` when no static ar…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.16] unreleased
+## [0.10.16] 2025-04-08
 
 ### Changed
 
 * Added all compat entries.
+* `get_vector` on `Circle` no longer returns `SArray` when no static arrays are passed as arguments.
 
 ### Fixed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.15"
+version = "0.10.16"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/manifolds/Circle.jl
+++ b/src/manifolds/Circle.jl
@@ -224,7 +224,8 @@ function get_coordinates_orthonormal(::Circle{ℂ}, p, X, ::Union{RealNumbers,Co
     return @SVector [Xⁱ]
 end
 
-get_vector_orthonormal(::Circle{ℝ}, p, c, ::RealNumbers) = Scalar(c[])
+get_vector_orthonormal(::Circle{ℝ}, p::StaticArray, c, ::RealNumbers) = Scalar(c[])
+get_vector_orthonormal(::Circle{ℝ}, p, c, ::RealNumbers) = fill(c[])
 # the method below is required for FD and AD differentiation in ManifoldDiff.jl
 # if changed, make sure no tests in that repository get broken
 get_vector_orthonormal(::Circle{ℝ}, p::AbstractVector, c, ::RealNumbers) = c
@@ -238,8 +239,16 @@ end
 
 Return tangent vector from the coordinates in the Lie algebra of the [`Circle`](@ref).
 """
-function get_vector_orthonormal(::Circle{ℂ}, p, c, ::Union{RealNumbers,ComplexNumbers})
+function get_vector_orthonormal(
+    ::Circle{ℂ},
+    p::StaticArray,
+    c,
+    ::Union{RealNumbers,ComplexNumbers},
+)
     @SArray fill(1im * c[1] * p[1])
+end
+function get_vector_orthonormal(::Circle{ℂ}, p, c, ::Union{RealNumbers,ComplexNumbers})
+    return fill(1im * c[1] * p[1])
 end
 function get_vector_orthonormal!(::Circle{ℂ}, X, p, c, ::Union{RealNumbers,ComplexNumbers})
     X .= 1im * c[1] * p[1]

--- a/test/manifolds/circle.jl
+++ b/test/manifolds/circle.jl
@@ -233,6 +233,8 @@ using Manifolds: TFVector, CoTFVector
         project!(Mc, p, p)
         @test p == @MArray fill(1.0 + 0.0im)
 
+        @test get_vector(Mc, fill(1.0 + 0.0im), [1.0]) isa Array{ComplexF64,0}
+
         angles = map(pp -> exp(pp * im), [-π / 2, 0.0, π])
         @test mean(Mc, angles) ≈ exp(-π * im / 2)
         @test mean(Mc, angles, [1.0, 1.0, 1.0]) ≈ exp(-π * im / 2)


### PR DESCRIPTION
…rays are passed as arguments

Otherwise LieGroups.jl doesn't like it.