### PR TITLE
fix supertype of a few tangent vectors that were `<: AbstractManifoldPoint`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.group }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,18 +1,15 @@
-name: CI
+name: nightly
 on:
-  push:
-    branches: [master]
-    tags: [v*]
   pull_request:
 
 jobs:
   test:
-    name: Julia ${{ matrix.julia-version }} - ${{ matrix.group }} - ${{ matrix.os }}
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ["lts", "1"]
-        os: [ubuntu-latest, macOS-latest]
+        julia-version: ["pre"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         group:
           - 'test_manifolds'
           - 'test_lie_groups'
@@ -23,17 +20,9 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
-      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
         env:
           PYTHON: ""
           MANIFOLDS_TEST_GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./lcov.info
-          name: codecov-umbrella
           fail_ci_if_error: false
-        if: ${{ matrix.os =='ubuntu-latest' }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.18] unreleasdd
+
+### Fixed
+
+* Fix the supertype of `PoincareBallTangentVector` to be `AbstractTangentVector`
+
 ## [0.10.17] - 2025-04-21
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fix the supertype of `PoincareBallTangentVector` to be `AbstractTangentVector`
+* Fix the supertype of `StifelTangentVector` to be `AbstractTangentVector`
 
 ## [0.10.17] - 2025-04-21
 

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -693,11 +693,13 @@ export Euclidean,
     UnitaryMatrices
 # Point representation types
 export HyperboloidPoint,
+    OrthogonalPoint,
     PoincareBallPoint,
     PoincareHalfSpacePoint,
+    StiefelFactorization,
+    StiefelPoint,
     SVDMPoint,
     TuckerPoint,
-    StiefelPoint,
     ProjectorPoint,
     SPDPoint
 # Tangent vector representation types

--- a/src/manifolds/GrassmannStiefel.jl
+++ b/src/manifolds/GrassmannStiefel.jl
@@ -21,7 +21,7 @@ the tangent space of a corresponding point from the [`Stiefel`](@ref) manifold,
 see [`StiefelPoint`](@ref).
 This is the default representation so is can be used interchangeably with just abstract matrices.
 """
-struct StiefelTangentVector{T<:AbstractMatrix} <: AbstractManifoldPoint
+struct StiefelTangentVector{T<:AbstractMatrix} <: AbstractTangentVector
     value::T
 end
 

--- a/src/manifolds/Hyperbolic.jl
+++ b/src/manifolds/Hyperbolic.jl
@@ -87,7 +87,7 @@ end
 In the Poincaré ball model of the [`Hyperbolic`](@ref) ``\mathcal H^n`` tangent vectors are represented
 as vectors in ``ℝ^{n}``.
 """
-struct PoincareBallTangentVector{TValue<:AbstractVector} <: AbstractManifoldPoint
+struct PoincareBallTangentVector{TValue<:AbstractVector} <: AbstractTangentVector
     value::TValue
 end
 


### PR DESCRIPTION
Just saw that a super type was wrong – this can wait for the next larger thing to be fixed I think, but awe could maybe merge it already to master.