### PR TITLE
Fix `riemannian_gradient` on Fixed Rank,

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.18] unreleasdd
+## [0.10.18] unreleasd
 
 ### Fixed
 
 * Fix the supertype of `PoincareBallTangentVector` to be `AbstractTangentVector`
-* Fix the supertype of `StifelTangentVector` to be `AbstractTangentVector`
+* Fix the supertype of `StiefelTangentVector` to be `AbstractTangentVector`
+* Fix `riemannian_gradient` for fixed rank matrices,
+  which did not work due to a small but in the default fallback and a missing metric specification.
 
 ## [0.10.17] - 2025-04-21
 

--- a/src/manifolds/FixedRankMatrices.jl
+++ b/src/manifolds/FixedRankMatrices.jl
@@ -51,7 +51,9 @@ function FixedRankMatrices(
     return FixedRankMatrices{typeof(size),field}(size)
 end
 
-active_traits(f, ::FixedRankMatrices, args...) = merge_traits(IsEmbeddedManifold())
+function active_traits(f, ::FixedRankMatrices, args...)
+    return merge_traits(IsEmbeddedManifold(), IsDefaultMetric(EuclideanMetric()))
+end
 
 @doc raw"""
     SVDMPoint <: AbstractManifoldPoint

--- a/src/manifolds/MetricManifold.jl
+++ b/src/manifolds/MetricManifold.jl
@@ -116,7 +116,7 @@ function change_representer!(
 end
 # Default fallback II: compute in local metric representations
 function change_representer!(M::AbstractManifold, Y, G::AbstractMetric, p, X)
-    M.metric === G && return copyto!(M, Y, p, X) # no metric change
+    is_default_metric(M, G) && return copyto!(M, Y, p, X) # no metric change
     # TODO: For local metric, inverse_local metric, det_local_metric: Introduce a default basis?
     B = DefaultOrthogonalBasis()
     G1 = local_metric(M, p, B)


### PR DESCRIPTION
this PR fixes #809, since the `EuclideanMetric` was not yet declared as the default metric for fixed rank, and there was a small bug in one of the fallbacks.

We now have again

```
julia> using Manifolds

julia> p = rand(M);

julia> Manifolds.riemannian_gradient(M, p, zeros(4,3)) # Assume the last argument is the Euclidean gradient, this now converts
UMVTangentVector{Matrix{Float64}, Matrix{Float64}, Matrix{Float64}}
U factor:
 4×2 Matrix{Float64}:
  0.0  0.0
  0.0  0.0
  0.0  0.0
  0.0  0.0
M factor:
 2×2 Matrix{Float64}:
  0.0  0.0
  0.0  0.0
Vt factor:
 2×3 Matrix{Float64}:
  0.0  0.0  0.0
  0.0  0.0  0.0
```

Should we release this as a patch version then? Then I would bump version and such.