### PR TITLE
Removed expicit complex conjugate in Stiefel.jl documentation

### DIFF
--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -14,10 +14,10 @@ where ``𝔽 ∈ \{ℝ, ℂ\}``,
 The tangent space at a point ``p ∈ \mathcal M`` is given by
 
 ````math
-T_p \mathcal M = \{ X ∈ 𝔽^{n×k} : p^{\mathrm{H}}X + \overline{X^{\mathrm{H}}p} = 0_k\},
+T_p \mathcal M = \{ X ∈ 𝔽^{n×k} : p^{\mathrm{H}}X + X^{\mathrm{H}}p = 0_k\},
 ````
 
-where ``0_k`` is the ``k×k`` zero matrix and ``\overline{⋅}`` the (elementwise) complex conjugate.
+where ``0_k`` is the ``k×k`` zero matrix.
 
 This manifold is modeled as an embedded manifold to the [`Euclidean`](@ref), i.e.
 several functions like the [`inner`](@ref inner(::Euclidean, ::Any...)) product and the
@@ -99,8 +99,7 @@ end
 
 Checks whether `X` is a valid tangent vector at `p` on the [`Stiefel`](@ref)
 `M`=``\operatorname{St}(n,k)``, i.e. the [`AbstractNumbers`](@extref ManifoldsBase number-system) fits and
-it (approximately) holds that ``p^{\mathrm{H}}X + \overline{X^{\mathrm{H}}p} = 0``,
-where ``⋅^{\mathrm{H}}`` denotes the Hermitian and ``\overline{⋅}`` the (elementwise) complex conjugate.
+it (approximately) holds that ``p^{\mathrm{H}}X + X^{\mathrm{H}}p = 0``.
 The settings for approximately can be set with `kwargs...`.
 """
 function check_vector(M::Stiefel, p, X; kwargs...)


### PR DESCRIPTION
Removed the complex conjugate over the second term in the tangent space condition, because it should not be there. It now matches the description given in Generalized Stiefel. See below for a short proof of why. 

For some interval, $I=[a,b]$ where $a,b\in \mathbb{R}$, the parametrized curve is the smooth map $c\colon I\to \mathcal{M}$. It is $c(t)\in {St}(n,k)$ where $c(0)=p$ and, the velocity of the curve is $c'(0)=X$. Since $c(t)$ is in ${St}(n,k)$, it must satisfy
$c(t)^{\mathrm{H}}c(t)=I_{k}$ 
for all $t\in I$. Taking the derivative of with respect to $t$ at $t=0$ the expression becomes
$c'(t)^{\mathrm{H}}c(t)+c(t)^{\mathrm{H}}c'(t)=X^{\mathrm{H}}p+p^{\mathrm{H}}X=0_{k}.$
This means that the tangent space of ${St}(n,k)$ at the point $p$ is
${T}_{p}{St}(n,k)=\{ p \in \mathbb{C}^{n\times k}\;|\;X^{\mathrm{H}}p=-p^{\mathrm{H}}X \}.$
