### PR TITLE
Fix project and embedd of tangent vectors for General Linear

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.19] unreleased
+
+### Fixed
+
+* Fix the projection and embedding of tangent vectors on `GeneralLinear`.
+
 ## [0.10.18] 2025-05-29
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.18"
+version = "0.10.19"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/ext/ManifoldsTestExt/tests_general.jl
+++ b/ext/ManifoldsTestExt/tests_general.jl
@@ -603,7 +603,7 @@ function test_manifold(
                 end
                 # check projection idempotency
                 for i in 1:N
-                    Test.@test isapprox(M, p, project(M, p, bvectors[i]), bvectors[i])
+                    Test.@test isapprox(M, p, project(M, p, bvectors[i]), p \ bvectors[i])
                 end
             end
             if !isa(btype, ProjectedOrthonormalBasis) && (

--- a/src/groups/general_linear.jl
+++ b/src/groups/general_linear.jl
@@ -72,9 +72,11 @@ tangent space which is done by ``Y = pX``.
 This can be done in-place of `Y`.
 """
 
-@doc _docs_embed_GL embed(::GeneralLinear, p, X) = p * X
+@doc "$(_docs_embed_GL)"
+embed(::GeneralLinear, p, X) = p * X
 
-@doc _docs_embed_GL embed!(::GeneralLinear, Y, p, X) = copyto!(Y, p * X)
+@doc "$(_docs_embed_GL)"
+embed!(::GeneralLinear, Y, p, X) = copyto!(Y, p * X)
 
 @doc raw"""
     exp(G::GeneralLinear, p, X)
@@ -272,8 +274,11 @@ identity operation here, tangent vectors on [`GeneralLinear`](@ref) are represen
 Lie Algebra, such that this projection has to solve ``pY = X``.
 """
 
-@doc _docs_project_GL project(::GeneralLinear, p, X) = p \ X
-@doc _docs_project_GL project!(::GeneralLinear, Y, p, X) = copyto!(Y, p \ X)
+@doc "$(_docs_project_GL)"
+project(::GeneralLinear, p, X) = p \ X
+
+@doc "$(_docs_project_GL)"
+project!(::GeneralLinear, Y, p, X) = copyto!(Y, p \ X)
 
 @doc raw"""
     Random.rand(G::GeneralLinear; vector_at=nothing, kwargs...)

--- a/src/groups/general_linear.jl
+++ b/src/groups/general_linear.jl
@@ -58,7 +58,23 @@ end
 distance(G::GeneralLinear, p, q) = norm(G, p, log(G, p, q))
 
 embed(::GeneralLinear, p) = p
-embed(::GeneralLinear, p, X) = X
+embed!(::GeneralLinear, q, p) = copyto!(q, p)
+
+_docs_embed_GL = raw"""
+    embed(G::GeneralLinear, p, X)
+    embed!(G::GeneralLinear, Y, p, X)
+
+Embedding a tangent vector `X` at `p` would usually be the identity,
+but on [`GeneralLinear`](@ref) the tangent vectors are represented in the Lie algebra,
+hence embedding this tangent vector means we have to transport it back to the right
+tangent space which is done by ``Y = pX``.
+
+This can be done in-place of `Y`.
+"""
+
+@doc _docs_embed_GL embed(::GeneralLinear, p, X) = p * X
+
+@doc _docs_embed_GL embed!(::GeneralLinear, Y, p, X) = copyto!(Y, p * X)
 
 @doc raw"""
     exp(G::GeneralLinear, p, X)
@@ -244,10 +260,20 @@ parallel_transport_to(::GeneralLinear, p, X, q) = X
 parallel_transport_to!(::GeneralLinear, Y, p, X, q) = copyto!(Y, X)
 
 project(::GeneralLinear, p) = p
-project(::GeneralLinear, p, X) = X
-
 project!(::GeneralLinear, q, p) = copyto!(q, p)
-project!(::GeneralLinear, Y, p, X) = copyto!(Y, X)
+
+_docs_project_GL = raw"""
+    project(G::GeneralLinear, p, X)
+    project!(G::GeneralLinear, Y, p, X)
+
+Project a tangent vector `X` from the embedding, that is the space of ``n×n`` matrices.
+While the tangent space at every point of the [`GeneralLinear`](@ref) would yield the
+identity operation here, tangent vectors on [`GeneralLinear`](@ref) are represented in the
+Lie Algebra, such that this projection has to solve ``pY = X``.
+"""
+
+@doc _docs_project_GL project(::GeneralLinear, p, X) = p \ X
+@doc _docs_project_GL project!(::GeneralLinear, Y, p, X) = copyto!(Y, p \ X)
 
 @doc raw"""
     Random.rand(G::GeneralLinear; vector_at=nothing, kwargs...)


### PR DESCRIPTION
Though already deprecated, this is a fix of GL(n) concerning embed/project of tangent vectors due to their representation in the Lie algebra, cf. https://github.com/JuliaManifolds/Manopt.jl/issues/473#issuecomment-2955075922


# 📋
* [x] fix project/embed
* [x] extend documentation
* [x] `News.md` updated
* [x] bump version number
* [ ] check code coverage  