### PR TITLE
Remove incorrect architecture choice in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: x64
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest


### PR DESCRIPTION
MacOS ARM does not have x86 so you're doing bad things here https://github.com/JuliaLang/julia/issues/55878 and https://github.com/julia-actions/setup-julia/pull/300