### PR TITLE
Be more precise when extending functions that were not imported.

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -17,7 +17,7 @@ jobs:
           version: "1.7.29"
       - uses: julia-actions/setup-julia@latest
         with:
-          version: "1.11"
+          version: "1.12"
       - name: Julia Cache
         uses: julia-actions/cache@v2
       - name: Cache Quarto

--- a/src/manifolds/Hamiltonian.jl
+++ b/src/manifolds/Hamiltonian.jl
@@ -24,7 +24,7 @@ end
 # Avoid double wrapping / unwrap if that happened
 Hamiltonian(A::Hamiltonian) = Hamiltonian(A.value)
 # Conversion
-function Matrix(A::Hamiltonian)
+function Base.Matrix(A::Hamiltonian)
     return Matrix(A.value)
 end
 

--- a/src/manifolds/PowerManifold.jl
+++ b/src/manifolds/PowerManifold.jl
@@ -20,7 +20,7 @@ tangent space of the power manifold.
 """
 struct PowerMetric <: AbstractMetric end
 
-function PowerManifold(
+function ManifoldsBase.PowerManifold(
         M::AbstractManifold{𝔽},
         size::Integer...;
         parameter::Symbol = :field,


### PR DESCRIPTION
On Julia 1.12, there is now a warning when extending a function that was loaded with `using` but not imported. 
I prefer to slowly move over to not import but sully specify, so the two fixes here follow that idea as well.