### PR TITLE
Use a stabilized variant of the exponential map on abstract spheres.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.2] unreleased
+## [0.11.2] 2025-10-30
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* fixed the `default_retraction_method` for `AbstractSphere` to be the stabilized exponential map to avoid accumulations of rounding errors
+  when the tangent vector is not exactly tangent.
 * fixed the contributing.md to mention runic as the code formatter.
 
 ## [0.11.1] 2025-10-24

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -287,6 +287,7 @@ using ManifoldsBase:
     ShootingInverseRetraction,
     SoftmaxRetraction,
     SoftmaxInverseRetraction,
+    StabilizedRetraction,
     StopForwardingType,
     TangentSpace,
     TangentSpaceType,
@@ -721,7 +722,8 @@ export AbstractRetractionMethod,
     OrthographicRetraction,
     PadeRetraction,
     ProductRetraction,
-    SasakiRetraction
+    SasakiRetraction,
+    StabilizedRetraction
 # Inverse Retraction types
 export AbstractInverseRetractionMethod,
     ApproximateInverseRetraction,

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -426,6 +426,16 @@ function default_approximation_method(::AbstractSphere, ::typeof(mean))
     return GeodesicInterpolationWithinRadius(π / 2)
 end
 
+"""
+    default_retraction_method(M::AbstractSphere)
+
+The default retraction on the sphere is usually the exponential map. Howeverm since that map
+tends to be very sensitive to also only slight errors in tangent vectors (not being tangent),
+we use a stabilized version as default that projects onto the sphere afterwards, see
+[`StabilizedRetraction`](@extref `ManifoldsBase.StabilizedRetraction`).
+"""
+default_retraction_method(::AbstractSphere) = StabilizedRetraction(ExponentialRetraction())
+
 function mid_point!(S::Sphere, q, p1, p2)
     q .= p1 .+ p2
     project!(S, q, q)

--- a/test/manifolds/sphere.jl
+++ b/test/manifolds/sphere.jl
@@ -22,6 +22,7 @@ using ManifoldsBase: TFVector
         @test_throws DomainError is_point(M, [2.0, 0.0, 0.0]; error = :error)
         @test !is_point(M, [2.0, 0.0, 0.0])
         @test !is_vector(M, [1.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+        @test default_retraction_method(M) == StabilizedRetraction(ExponentialRetraction())
         @test_throws DomainError is_vector(
             M,
             [1.0, 0.0, 0.0],


### PR DESCRIPTION
in order to avoid accumulation of rounding errors (which is worse than the overhead to project).