### PR TITLE
Fix a transpose bug in the inverse retraction of Polar Light.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.15] 2026-03-04
+
+### Fixed
+
+* fixed a missing transpose in the inverse polar light retraction.
+
 ## [0.11.14] 2026-03-02
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.14"
+version = "0.11.15"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/manifolds/Stiefel.jl
+++ b/src/manifolds/Stiefel.jl
@@ -320,9 +320,9 @@ function inverse_retract_polar_light!(::Stiefel, X, p, q)
     U, d, V = s.U, s.S, s.V
     # sets X to the second summand in the python code
     X .= q * V * Diagonal(1 ./ d) * V'
-    copyto!(U, U * V) # MRT in the python code
+    copyto!(U, U * V') # MRT in the python code - use memory of U
     L = log(U)
-    L .= L .- U
+    L .= L .- U # log(MRT) - MRT
     # add the first summand
     X .+= p * L
     return X


### PR DESCRIPTION
While trying to “quickly hack” the first experiment from Jensen&Zimmermann – nothing really worked. So I went back and compared the formulae and code. I missed a transpose.

I am not sure now how to add a test for this, since in low dimensions (the ones we do test) `V` and `V'` always seem identical for the examples I tried, but with large random points and matrices (1000x400) the X from the inv _retr would not even yield a valid tangent vector. 