### PR TITLE
Add human-readable citation and links, move BibLaTeX to a folded block.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.20] unreleased
+
+### Changed
+
+* Improved formatting of the references in the Readme.md (#869)
+
 ## [0.11.19] 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,16 @@ If you have any questions regarding the Manifolds.jl ecosystem feel free to reac
 
 ## Citation
 
-If you use `Manifolds.jl` in your work, please cite the following open access article
+If you use `Manifolds.jl` in your work, please cite the following open access article:
+
+> _Axen, S. D., Baran, M., Bergmann, R., Rzecki, K._ (2023).
+> **Manifolds.jl: An Extensible Julia Framework for Data Analysis on Manifolds**,
+> ACM Transactions on Mathematical Software, Volume 49, Issue 4, Article No. 33, pages 1–23. <br>
+> doi: [10.1145/3618296](https://doi.org/10.1145/3618296),
+> arXiv: [2106.08777](https://arxiv.org/abs/2106.08777)
+<details>
+
+  <summary><code>AxenBaranBergmannRzecki:2023</code>(BibLaTeX)</summary>
 
 ```biblatex
 @article{AxenBaranBergmannRzecki:2023,
@@ -69,13 +78,23 @@ If you use `Manifolds.jl` in your work, please cite the following open access ar
 }
 ```
 
-To refer to a certain version we recommend to also cite for example
+</details>
+
+To refer to a certain version we recommend to also cite the code repository directly.
+For example to refer to the most recent version
+
+> _Axen, S. D., Baran, M., Bergmann, R._ (2026). **Manifolds.jl**, Zenodo.<br>
+> doi: [10.5281/zenodo.4292129](https://doi.org/10.5281/zenodo.4292129)
+
+<details>
+
+  <summary><code>Manifoldsjl-zenodo-mostrecent</code> (BibLaTeX)</summary>
 
 ```biblatex
 @software{manifoldsjl-zenodo-mostrecent,
   Author = {Seth D. Axen and Mateusz Baran and Ronny Bergmann},
   Title = {Manifolds.jl},
-  Doi = {10.5281/ZENODO.4292129},
+  Doi = {10.5281/zenodo.4292129},
   Url = {https://zenodo.org/record/4292129},
   Publisher = {Zenodo},
   Year = {2021},
@@ -83,5 +102,6 @@ To refer to a certain version we recommend to also cite for example
 }
 ```
 
-for the most recent version or a corresponding version specific DOI, see [the list of all versions](https://zenodo.org/search?page=1&size=20&q=conceptrecid:%224292129%22&sort=-version&all_versions=True).
-Note that both citations are in [BibLaTeX](https://ctan.org/pkg/biblatex) format.
+</details>
+
+for a corresponding version specific DOI, see [the list of all versions](https://zenodo.org/search?page=1&size=20&q=conceptrecid:%224292129%22&sort=-version&all_versions=True).

--- a/ext/ManifoldsRecursiveArrayToolsExt/ManifoldsRecursiveArrayToolsExt.jl
+++ b/ext/ManifoldsRecursiveArrayToolsExt/ManifoldsRecursiveArrayToolsExt.jl
@@ -39,6 +39,10 @@ function allocate(
     return similar(x)
 end
 
+function allocate_result(M::AbstractDecoratorManifold, f::typeof(get_parameters), p::ArrayPartition)
+    return @invoke allocate_result(M, f, p::Any)
+end
+
 recursive_bottom_eltype(::TuckerPoint{T}) where {T} = T
 recursive_bottom_eltype(::TuckerTangentVector{T}) where {T} = T
 

--- a/ext/ManifoldsRecursiveArrayToolsExt/ManifoldsRecursiveArrayToolsExt.jl
+++ b/ext/ManifoldsRecursiveArrayToolsExt/ManifoldsRecursiveArrayToolsExt.jl
@@ -39,8 +39,12 @@ function allocate(
     return similar(x)
 end
 
-function allocate_result(M::AbstractDecoratorManifold, f::typeof(get_parameters), p::ArrayPartition)
-    return @invoke allocate_result(M, f, p::Any)
+for MT in [AbstractDecoratorManifold, ProductManifold]
+    @eval begin
+        function allocate_result(M::$MT, f::typeof(get_parameters), p::ArrayPartition)
+            return @invoke allocate_result(M, f, p::Any)
+        end
+    end
 end
 
 recursive_bottom_eltype(::TuckerPoint{T}) where {T} = T

--- a/ext/ManifoldsRecursiveArrayToolsExt/ProductManifoldRAT.jl
+++ b/ext/ManifoldsRecursiveArrayToolsExt/ProductManifoldRAT.jl
@@ -19,6 +19,11 @@ function adjoint_Jacobi_field(
     )
 end
 
+function allocate_result(M::ProductManifold, f::typeof(get_point), a::AbstractVector)
+    return ArrayPartition(map(M_i -> allocate_result(M_i, f, a), M.manifolds)...)
+end
+
+
 function jacobi_field(
         M::ProductManifold,
         p::ArrayPartition,

--- a/test/manifolds-old/product_manifold.jl
+++ b/test/manifolds-old/product_manifold.jl
@@ -246,6 +246,14 @@ using RecursiveArrayTools: ArrayPartition
         @test all(submanifold_components(p2) .== submanifold_components(p))
     end
 
+    @testset "Atlas & allocation" begin
+        M = ProductManifold(Manifolds.EmbeddedTorus(2.0, 1.0), Manifolds.EmbeddedTorus(2.0, 1.0))
+        p0x = [0.5, -1.2]
+        p = ArrayPartition(([Manifolds._torus_param(Mi, p0x...)...] for Mi in M.manifolds)...)
+        @test length(allocate_result(M, get_parameters, p)) == 4
+        @test allocate_result(M, get_point, zeros(4)) isa typeof(p)
+    end
+
     @testset "metric conversion" begin
         M = SymmetricPositiveDefinite(3)
         N = ProductManifold(M, M)


### PR DESCRIPTION
Following the suggestion by @eschnett in #868 I reformatted the bibliographic remarks in the readme:
* added a human readable (Havard style) reference including links (DOI and when existent arXiv)
* moved the BibLaTeX reference code blocks to be folded away - hopefully still clear enough that those are the BibLaTeX “thingies” one can simply copy.

The preview is here https://github.com/JuliaManifolds/Manifolds.jl/tree/kellertuer/format-references or (the following is a screenshot in dark mode):

<img width="1149" height="605" alt="Screenshot 2026-03-23 at 09 43 49" src="https://github.com/user-attachments/assets/4961604a-0d9d-41c6-bb7d-bef836af27b5" />

What do you think Erik?

