### PR TITLE
🦺 Migrate Remaining Manifold Tests to New Suite & Tracking List

### DIFF
--- a/test/manifolds-old/direct_sum_bundle.jl
+++ b/test/manifolds-old/direct_sum_bundle.jl
@@ -2,7 +2,7 @@ using Test
 using Manifolds
 using RecursiveArrayTools
 
-@testset "Multitangent bundle" begin
+@testset "direct_sum_bundle" begin
     M = Sphere(2)
     m_prod_retr = Manifolds.FiberBundleProductRetraction()
     m_prod_invretr = Manifolds.FiberBundleInverseProductRetraction()
@@ -28,7 +28,6 @@ using RecursiveArrayTools
 
     p = [1.0, 0.0, 0.0]
     TB = Manifolds.MultitangentBundle{2}(M)
-    # @test sprint(show, TB) == "TangentBundle(Sphere(2, ℝ))"
     @test base_manifold(TB) == M
     @test manifold_dimension(TB) == 3 * manifold_dimension(M)
     @test representation_size(TB) === nothing


### PR DESCRIPTION
Closes https://github.com/JuliaManifolds/Manifolds.jl/issues/870

This PR continues the effort to transition all Manifolds.jl tests to the new test suite, building upon previous work in #839 and #847. It provides a comprehensive list of remaining manifold tests to migrate, along with associated tests to review for removal and potential new tests to implement as the API evolves, aiming for full test suite coverage. 

This approach allows for focused contributions and serves as a helpful guide for developers interested in exploring specific manifolds and their testing.