### PR TITLE
Add projection transport for Segre

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.24] 2026-05-07
 ### Added
-`vector_transport_to(::Segre, p, X, q, ::ProjectionTransport)` for Segre Manifold
+`vector_transport_to(::Segre, p, X, q, ::ProjectionTransport)` for Segre Manifold (#893)
 
 ## [0.11.23] 2026-04-29
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,10 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.24] 2026-05-07
+### Added
+`vector_transport_to(::Segre, p, X, q, ::ProjectionTransport)` for Segre Manifold
+
 ## [0.11.23] 2026-04-29
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.24] 2026-05-07
+## [0.11.24] 2026-05-19
+
 ### Added
 `vector_transport_to(::Segre, p, X, q, ::ProjectionTransport)` for Segre Manifold (#893)
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.23"
+version = "0.11.24"
 
 [workspace]
 projects = ["test", "docs", "tutorials"]

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -170,16 +170,12 @@ function ManifoldsBase.vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q
     d = length(V)
     λ = q[1][1]
 
-    # Initialize output tangent vector Y at q.
     for Yi in Y
         fill!(Yi, zero(eltype(Yi)))
     end
 
-    # Reusable storage for dot products <z_k, x_k>.
     dots = Vector{typeof(dot(p[2], q[2]))}(undef, d)
 
-    # term = 0 corresponds to ν y₁ ⊗ ⋯ ⊗ y_d.
-    # term = k corresponds to λ_p y₁ ⊗ ⋯ ⊗ u_k ⊗ ⋯ ⊗ y_d.
     for term in 0:d
         c = term == 0 ? X[1][1] : p[1][1]
 

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -168,64 +168,53 @@ the embedded tangent vector ``D\Phi_p[X]`` onto the tangent space of `M` at `q`.
 
 Let
 ````math
-p = (\mu, y_1,\ldots,y_d), 
-\qquad 
-X = (\nu,u_1,\ldots,u_d) \in T_pM,
+p = (μ, y_1,…,y_d),
+\qquad
+X = (ν,u_1,…,u_d) ∈ T_pM,
 ````
-and let ``q = (\lambda,x_1,\ldots,x_d)``.
+and let ``q = (λ,x_1,…,x_d)``.
 
 Under the Segre parametrization
 ````math
-\Phi(\lambda,x_1,\ldots,x_d) 
-= 
-\lambda\, x_1\otimes\cdots\otimes x_d,
+Φ(λ,x_1,…,x_d)
+=
+λ\, x_1 ⊗⋯⊗ x_d,
 ````
 
 the embedded tangent vector at ``p`` is
 ````math
-D\Phi_p[X]
+DΦ_p[X]
 =
-\nu\, y_1\otimes\cdots\otimes y_d
+ν\, y_1 ⊗⋯⊗ y_d
 +
-\mu
-\sum_{k=1}^d
-y_1\otimes\cdots\otimes u_k\otimes\cdots\otimes y_d .
+μ \sum_{k=1}^d y_1 ⊗⋯⊗ u_k ⊗⋯⊗ y_d .
 ````
 
 Projection vector transport from ``T_pM`` to ``T_qM`` is given by
 ````math
-Y = \Pi_{T_qM}\bigl(D\Phi_p[X]\bigr),
+Y = Π_{T_qM}\bigl(DΦ_p[X]\bigr),
 ````
 
 where
 ````math
-Y = (\dot{\lambda},v_1,\ldots,v_d)\in T_qM.
+Y = (\dot{\lambda},v_1,…,v_d) ∈ T_qM.
 ````
 
-For each rank-one term ``c\,z_1\otimes\cdots\otimes z_d``,
+For each rank-one term ``c\,z_1 ⊗⋯⊗ z_d``,
 its contribution to ``Y`` is
 ````math
-\dot{\lambda}
-\mathrel{+}=
-c\prod_{j=1}^d \langle z_j,x_j\rangle,
+\dot{\lambda} \mathrel{+}= c\prod_{j=1}^d ⟨ z_j, x_j ⟩,
 ````
 
-and, for each ``k=1,\ldots,d``,
+and, for each ``k=1,…,d``,
 ````math
-v_k
-\mathrel{+}=
-\frac{c}{\lambda}
-\left(
-\prod_{j\neq k}\langle z_j,x_j\rangle
-\right)
-\left(
-z_k-\langle z_k,x_k\rangle x_k
-\right).
+v_k \mathrel{+}= \frac{c}{\lambda}
+\left( ∏_{j≠k} ⟨ z_j, x_j ⟩ \right)\left( z_k - ⟨ z_k, x_k⟩ x_k \right).
 ````
-The implementation uses this rank-one structure and therefore avoids explicitly 
+The implementation uses this rank-one structure and therefore avoids explicitly
 forming the ambient tensor.
 """
-vector_transport_to(M::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport) where {V}
+vector_transport_to(::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport) where {V}
 
 function vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q) where {V}
     d = length(V)

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -167,13 +167,14 @@ Compute projection vector transport on the [`Segre`](@ref) manifold by projectin
 the embedded tangent vector ``D\Phi_p[X]`` onto the tangent space of `M` at `q`.
 
 Let
-
-``p = (\mu, y_1,\ldots,y_d)``, ``\qquad X = (\nu,u_1,\ldots,u_d) \in T_pM``,
-and let
-``q = (\lambda,x_1,\ldots,x_d)``.
+````math
+p = (\mu, y_1,\ldots,y_d), 
+\qquad 
+X = (\nu,u_1,\ldots,u_d) \in T_pM,
+````
+and let ``q = (\lambda,x_1,\ldots,x_d)``.
 
 Under the Segre parametrization
-
 ````math
 \Phi(\lambda,x_1,\ldots,x_d) 
 = 
@@ -181,7 +182,6 @@ Under the Segre parametrization
 ````
 
 the embedded tangent vector at ``p`` is
-
 ````math
 D\Phi_p[X]
 =
@@ -193,26 +193,17 @@ y_1\otimes\cdots\otimes u_k\otimes\cdots\otimes y_d .
 ````
 
 Projection vector transport from ``T_pM`` to ``T_qM`` is given by
-
-``Y = \Pi_{T_qM}\bigl(D\Phi_p[X]\bigr)``,
+````math
+Y = \Pi_{T_qM}\bigl(D\Phi_p[X]\bigr),
+````
 
 where
-
-``Y = (\dot{\lambda},v_1,\ldots,v_d)\in T_qM``.
-
-Equivalently, decompose ``D\Phi_p[X]`` as a sum of rank-one terms
-
 ````math
-D\Phi_p[X]
-=
-\sum_{\ell} c_\ell\,
-z_{\ell,1}\otimes\cdots\otimes z_{\ell,d}.
+Y = (\dot{\lambda},v_1,\ldots,v_d)\in T_qM.
 ````
 
 For each rank-one term ``c\,z_1\otimes\cdots\otimes z_d``,
-
 its contribution to ``Y`` is
-
 ````math
 \dot{\lambda}
 \mathrel{+}=
@@ -220,7 +211,6 @@ c\prod_{j=1}^d \langle z_j,x_j\rangle,
 ````
 
 and, for each ``k=1,\ldots,d``,
-
 ````math
 v_k
 \mathrel{+}=
@@ -234,7 +224,6 @@ z_k-\langle z_k,x_k\rangle x_k
 ````
 The implementation uses this rank-one structure and therefore avoids explicitly 
 forming the ambient tensor.
-
 """
 vector_transport_to(M::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport) where {V}
 

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -159,6 +159,60 @@ function embed!(::Segre{𝔽, V}, u, p, X) where {𝔽, V}
     )
 end
 
+
+@doc raw"""
+    vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q)
+
+Compute projection vector transport on the [`Segre`](@ref) manifold by projecting
+the embedded tangent vector ``D\Phi_p[X]`` onto the tangent space of `M` at `q`.
+"""
+function ManifoldsBase.vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q) where {V}
+    d = length(V)
+    λ = q[1][1]
+
+    # Initialize output tangent vector Y at q.
+    for Yi in Y
+        fill!(Yi, zero(eltype(Yi)))
+    end
+
+    # Reusable storage for dot products <z_k, x_k>.
+    dots = Vector{typeof(dot(p[2], q[2]))}(undef, d)
+
+    # term = 0 corresponds to ν y₁ ⊗ ⋯ ⊗ y_d.
+    # term = k corresponds to λ_p y₁ ⊗ ⋯ ⊗ u_k ⊗ ⋯ ⊗ y_d.
+    for term in 0:d
+        c = term == 0 ? X[1][1] : p[1][1]
+
+        for k in 1:d
+            zk = term == k ? X[k + 1] : p[k + 1]
+            dots[k] = dot(zk, q[k + 1])
+        end
+
+        Y[1][1] += c * prod(dots)
+
+        for k in 1:d
+            zk = term == k ? X[k + 1] : p[k + 1]
+            xk = q[k + 1]
+            vk = Y[k + 1]
+            αk = dots[k]
+
+            coeff = c / λ
+            for j in 1:d
+                if j != k
+                    coeff *= dots[j]
+                end
+            end
+
+            @inbounds for i in eachindex(vk, zk, xk)
+                vk[i] += coeff * (zk[i] - αk * xk[i])
+            end
+        end
+    end
+
+    return Y
+end
+
+
 """
     is_point(M::Segre{ℝ, V}, p; kwargs...)
 

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -165,6 +165,76 @@ end
 
 Compute projection vector transport on the [`Segre`](@ref) manifold by projecting
 the embedded tangent vector ``D\Phi_p[X]`` onto the tangent space of `M` at `q`.
+
+Let
+
+``p = (\mu, y_1,\ldots,y_d)``, ``\qquad X = (\nu,u_1,\ldots,u_d) \in T_pM``,
+and let
+``q = (\lambda,x_1,\ldots,x_d)``.
+
+Under the Segre parametrization
+
+````math
+\Phi(\lambda,x_1,\ldots,x_d) 
+= 
+\lambda\, x_1\otimes\cdots\otimes x_d,
+````
+
+the embedded tangent vector at ``p`` is
+
+````math
+D\Phi_p[X]
+=
+\nu\, y_1\otimes\cdots\otimes y_d
++
+\mu
+\sum_{k=1}^d
+y_1\otimes\cdots\otimes u_k\otimes\cdots\otimes y_d .
+````
+
+Projection vector transport from ``T_pM`` to ``T_qM`` is given by
+
+``Y = \Pi_{T_qM}\bigl(D\Phi_p[X]\bigr)``,
+
+where
+
+``Y = (\dot{\lambda},v_1,\ldots,v_d)\in T_qM``.
+
+Equivalently, decompose ``D\Phi_p[X]`` as a sum of rank-one terms
+
+````math
+D\Phi_p[X]
+=
+\sum_{\ell} c_\ell\,
+z_{\ell,1}\otimes\cdots\otimes z_{\ell,d}.
+````
+
+For each rank-one term ``c\,z_1\otimes\cdots\otimes z_d``,
+
+its contribution to ``Y`` is
+
+````math
+\dot{\lambda}
+\mathrel{+}=
+c\prod_{j=1}^d \langle z_j,x_j\rangle,
+````
+
+and, for each ``k=1,\ldots,d``,
+
+````math
+v_k
+\mathrel{+}=
+\frac{c}{\lambda}
+\left(
+\prod_{j\neq k}\langle z_j,x_j\rangle
+\right)
+\left(
+z_k-\langle z_k,x_k\rangle x_k
+\right).
+````
+The implementation uses this rank-one structure and therefore avoids explicitly 
+forming the ambient tensor.
+
 """
 vector_transport_to(M::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport) where {V}
 

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -212,8 +212,8 @@ and, for each ``k=1,…,d``,
 v_k
 = 
 \sum_{r=0}^{d} \frac{c_r}{\lambda}
-\left( ∏_{j≠k} ⟨ z_j, x_j ⟩ \right)
-\left( z_k - ⟨ z_k, x_k⟩ x_k \right).
+\left( ∏_{j≠k} ⟨ z_{r,j}, x_j ⟩ \right)
+\left( z_{r,k} - ⟨ z_{r,k}, x_k⟩ x_k \right).
 ````
 The implementation uses this rank-one structure and therefore avoids explicitly
 forming the ambient tensor.

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -161,12 +161,14 @@ end
 
 
 @doc raw"""
-    vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q)
+    vector_transport_to(M::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport)
 
 Compute projection vector transport on the [`Segre`](@ref) manifold by projecting
 the embedded tangent vector ``D\Phi_p[X]`` onto the tangent space of `M` at `q`.
 """
-function ManifoldsBase.vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q) where {V}
+vector_transport_to(M::Segre{ℝ, V}, Y, p, X, q, ::ProjectionTransport) where {V}
+
+function vector_transport_to_project!(M::Segre{ℝ, V}, Y, p, X, q) where {V}
     d = length(V)
     λ = q[1][1]
 

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -203,16 +203,15 @@ Y = (\dot{\lambda},v_1,…,v_d) ∈ T_qM.
 For each rank-one term ``c\,z_1 ⊗⋯⊗ z_d``,
 its contribution to ``Y`` is
 ````math
-\Delta \dot{\lambda}
-= 
-c\prod_{j=1}^d ⟨ z_j, x_j ⟩,
+\dot{\lambda}
+= \sum_{r=0}^{d} c_r \prod_{j=1}^{d} ⟨ z_{r,j},\, x_j ⟩
 ````
 
 and, for each ``k=1,…,d``,
 ````math
-\Delta v_k
-=
-\frac{c}{\lambda}
+v_k
+= 
+\sum_{r=0}^{d} \frac{c_r}{\lambda}
 \left( ∏_{j≠k} ⟨ z_j, x_j ⟩ \right)
 \left( z_k - ⟨ z_k, x_k⟩ x_k \right).
 ````

--- a/src/manifolds/Segre.jl
+++ b/src/manifolds/Segre.jl
@@ -203,13 +203,18 @@ Y = (\dot{\lambda},v_1,…,v_d) ∈ T_qM.
 For each rank-one term ``c\,z_1 ⊗⋯⊗ z_d``,
 its contribution to ``Y`` is
 ````math
-\dot{\lambda} \mathrel{+}= c\prod_{j=1}^d ⟨ z_j, x_j ⟩,
+\Delta \dot{\lambda}
+= 
+c\prod_{j=1}^d ⟨ z_j, x_j ⟩,
 ````
 
 and, for each ``k=1,…,d``,
 ````math
-v_k \mathrel{+}= \frac{c}{\lambda}
-\left( ∏_{j≠k} ⟨ z_j, x_j ⟩ \right)\left( z_k - ⟨ z_k, x_k⟩ x_k \right).
+\Delta v_k
+=
+\frac{c}{\lambda}
+\left( ∏_{j≠k} ⟨ z_j, x_j ⟩ \right)
+\left( z_k - ⟨ z_k, x_k⟩ x_k \right).
 ````
 The implementation uses this rank-one structure and therefore avoids explicitly
 forming the ambient tensor.

--- a/test/manifolds-old/segre.jl
+++ b/test/manifolds-old/segre.jl
@@ -174,6 +174,20 @@ using Manifolds, Test, Random, LinearAlgebra, FiniteDifferences
                 @test is_vector(get_embedding(M), p_, X_)
             end
 
+            @testset "vector_transport_to" begin
+                N = Segre(V...)
+
+                Z = vector_transport_to(N, p, X, q, ProjectionTransport())
+                @test is_vector(N, q, Z)
+
+                Z_same = vector_transport_to(N, p, X, p, ProjectionTransport())
+                @test isapprox(Z_same, X; atol = 1.0e-10)
+
+                Z_inplace = zero_vector(N, q)
+                vector_transport_to!(N, Z_inplace, p, X, q, ProjectionTransport())
+                @test isapprox(Z_inplace, Z; atol = 1.0e-10)
+            end
+            
             @testset "get_coordinates" begin
                 @test isapprox(X, get_vector(M, p, get_coordinates(M, p, X)))
                 @test isapprox(c, get_coordinates(M, p, get_vector(M, p, c)))

--- a/test/manifolds-old/segre.jl
+++ b/test/manifolds-old/segre.jl
@@ -187,7 +187,7 @@ using Manifolds, Test, Random, LinearAlgebra, FiniteDifferences
                 vector_transport_to!(N, Z_inplace, p, X, q, ProjectionTransport())
                 @test isapprox(Z_inplace, Z; atol = 1.0e-10)
             end
-            
+
             @testset "get_coordinates" begin
                 @test isapprox(X, get_vector(M, p, get_coordinates(M, p, X)))
                 @test isapprox(c, get_coordinates(M, p, get_vector(M, p, c)))


### PR DESCRIPTION
This PR implements `vector_transport_to_project!` for `Segre{ℝ,V}`.

This is my first code contribution to Manifolds.jl, so feedback on style, documentation, and test placement is very welcome.

