### PR TITLE
An ONB for Tangent spaces on Grassmann in Stiefel Representation.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.27] 2026-06-05
+
+## Added
+
+* a `DefaultOrthonormalBasis` for the `Grassmann` manifold in Stiefel representation.
+* improved documentation of the tangent space.
+
 ## [0.11.26] 2026-05-22
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,11 +5,11 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.11.27] 2026-06-05
+## [0.11.27] 2026-06-06
 
 ## Added
 
-* a `DefaultOrthonormalBasis` for the `Grassmann` manifold in Stiefel representation.
+* a `DefaultOrthonormalBasis` for the `Grassmann` manifold in Stiefel representation. (#904)
 * improved documentation of the tangent space.
 
 ## [0.11.26] 2026-05-22

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Manifolds"
 uuid = "1cead3c2-87b3-11e9-0ccd-23c62b72b94e"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.26"
+version = "0.11.27"
 
 [workspace]
 projects = ["test", "docs", "tutorials"]

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -37,7 +37,7 @@ T_p\mathrm{Gr}(n,k) = \bigl\{ X ∈ 𝔽^{n×k} : p^{\mathrm{H}}X = 0_{k} \bigr\
 where ``0_k`` is the ``k×k`` zero matrix.
 Note that this is a subspace (called the horizontal space) of the tangent space of the
 [`Stiefel`](@ref) manifold, whose tangent space requires ``p^{\mathrm{H}}X = -p^{\mathrm{H}}X``,
-which is here fulfilled for all ``X`` automatically, even for any “rotated basis” ``Qp``, ``Q ∈ \operatorname{O}(k)``
+which is here fulfilled for all ``X`` automatically, even for any “rotated basis” ``pQ``, ``Q ∈ \operatorname{O}(k)``
 
 Note that a point ``p ∈ \operatorname{Gr}(n,k)`` might be represented by
 different matrices (i.e. matrices with unitary column vectors that span

--- a/src/manifolds/Grassmann.jl
+++ b/src/manifolds/Grassmann.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    Grassmann{T,𝔽} <: AbstractDecoratorManifold{𝔽}
+    Grassmann{𝔽, T} <: AbstractDecoratorManifold{𝔽}
 
 The Grassmann manifold ``\mathrm{Gr}(n,k)`` consists of all subspaces spanned by ``k`` linear independent
 vectors ``𝔽^n``, where ``𝔽  ∈ \{ℝ, ℂ\}`` is either the real- (or complex-) valued vectors.
@@ -31,17 +31,17 @@ on the Stiefel manifold, the resulting quotient metric on Grassmann is the same.
 The tangent space at a point (subspace) ``p`` is given by
 
 ````math
-T_p\mathrm{Gr}(n,k) = \bigl\{
-X ∈ 𝔽^{n×k} :
-X^{\mathrm{H}}p + p^{\mathrm{H}}X = 0_{k} \bigr\},
+T_p\mathrm{Gr}(n,k) = \bigl\{ X ∈ 𝔽^{n×k} : p^{\mathrm{H}}X = 0_{k} \bigr\},
 ````
 
 where ``0_k`` is the ``k×k`` zero matrix.
+Note that this is a subspace (called the horizontal space) of the tangent space of the
+[`Stiefel`](@ref) manifold, whose tangent space requires ``p^{\mathrm{H}}X = -p^{\mathrm{H}}X``,
+which is here fulfilled for all ``X`` automatically, even for any “rotated basis” ``Qp``, ``Q ∈ \operatorname{O}(k)``
 
 Note that a point ``p ∈ \operatorname{Gr}(n,k)`` might be represented by
 different matrices (i.e. matrices with unitary column vectors that span
-the same subspace). Different representations of ``p`` also lead to different
-representation matrices for the tangent space ``T_p\mathrm{Gr}(n,k)``
+the same subspace).
 
 For a representation of points as orthogonal projectors. Here
 

--- a/src/manifolds/GrassmannStiefel.jl
+++ b/src/manifolds/GrassmannStiefel.jl
@@ -100,7 +100,7 @@ end
 
 Given a point `p` on the [`Grassmann`](@ref) manifold `M` in Stiefel representation,
 i.e. ``p ∈ ℝ^{n×k}`` compute the coordinates ``c ∈ ℝ^{k(n-k)}`` representing the
-tangent vector `X`.
+tangent vector `X` with respect to the [`DefaultOrthonormalBasis`](@extref `ManifoldsBase.DefaultOrthonormalBasis`).
 
 The tangent space is characterized by ``p^{\mathrm{T}}X = 0_{k×k}``,
 where ``0_{k×k}`` is the ``k×k`` matrix containing zeros
@@ -161,7 +161,7 @@ end
     get_vector(M::Grasmmann{ℝ}, p, c, B::DefaultOrthonormalBasis)
 
 Given a point `p` on the [`Grassmann`](@ref) manifold `M` in Stiefel representation,
-i.e. ``p ∈ ℝ^{n×k}`` reconstruct a tangent vector with respect to the [`DefaultOrthonormalBasis`](@ref)
+i.e. ``p ∈ ℝ^{n×k}`` reconstruct a tangent vector with respect to the [`DefaultOrthonormalBasis`](@extref `ManifoldsBase.DefaultOrthonormalBasis`)
 given coefficients ``c ∈ ℝ^{k(n-k)}``.
 
 The tangent space is characterized by ``p^{\mathrm{T}}X = 0_{k×k}``,

--- a/src/manifolds/GrassmannStiefel.jl
+++ b/src/manifolds/GrassmannStiefel.jl
@@ -94,6 +94,50 @@ function exp!(M::Grassmann, q, p, X)
     return copyto!(q, Array(qr(z).Q))
 end
 
+
+@doc raw"""
+    get_coordinates(M::Grasmmann{ℝ}, p, X, B::DefaultOrthonormalBasis)
+
+Given a point `p` on the [`Grassmann`](@ref) manifold `M` in Stiefel representation,
+i.e. ``p ∈ ℝ^{n×k}`` compute the coordinates ``c ∈ ℝ^{k(n-k)}`` representing the
+tangent vector `X`.
+
+The tangent space is characterized by ``p^{\mathrm{T}}X = 0_{k×k}``,
+where ``0_{k×k}`` is the ``k×k`` matrix containing zeros
+A default orthonormal basis can is constructed as follows: Since ``p`` has full
+column rank ``k``, the null space of ``p^{\mathrm{T}}`` is of dimension ``n-k``.
+Let ``v_1,…v_{n-k}`` be an orthonormal basis of that null space, then
+```math
+X_1 = \bigl(v_1, 0_k,…0_k), X_2 = \bigl(v_2 0_k,…,0_k), …, X_{n-k} = \bigl(v_{n-k} 0_k,…0_k),
+X_{n-k1} = \bigl(0_k, v_1, 0_k, …, 0_k), …, X_{(n-k)k} = (0_k,\ldots,0_k,v_{n-k}),
+```
+where ``0_k`` denotes the ``k``-dimensional zero vector.
+Let ``V = (v_1,…,v_{n-k}) ∈ ℝ^{n×(n-k)}`` be the matrix of the basis vectors
+
+For a tangent vector ``X`` we know that every column `X_i``, ``i=1,…,k`` lies in
+the span of ``v_1,…v_{n-k}`` by looking at every column of the matrix equation
+``p^{\mathrm{T}}X = 0_{k×k}``.
+
+Hence we can compute the coordinates ``c`` in ``k`` “blocks” ``C_1,…C_k ∈ ℝ^{n-k}``
+by solving the linear systems
+
+```math
+VC_i = X_i, \qquad i=1,…,k.
+```
+"""
+get_coordinates(::Grassmann{ℝ}, p, c, ::DefaultOrthonormalBasis)
+
+function get_coordinates_orthonormal!(M::Grassmann{ℝ}, c, p, X, ::RealNumbers)
+    n, k = get_parameter(M.size)
+    V = nullspace(p') # from SVD, so we have (n-k) ON columns in R^n
+    for i in 1:k
+        # The sum above in the docs is a MV product in blocks
+        # c[1:(n-k)], c[(n-k)+1:2*(n-k)],...with V
+        c[((i - 1) * (n - k) + 1):(i * (n - k))] .= V \ X[:, i]
+    end
+    return c
+end
+
 function get_embedding(::Grassmann{𝔽, TypeParameter{Tuple{n, k}}}) where {n, k, 𝔽}
     return Stiefel(n, k, 𝔽)
 end
@@ -113,6 +157,44 @@ function ManifoldsBase.get_forwarding_type(::Stiefel, f, ::Type{<:StiefelPoint})
     return ManifoldsBase.EmbeddedForwardingType()
 end
 
+@doc raw"""
+    get_vector(M::Grasmmann{ℝ}, p, c, B::DefaultOrthonormalBasis)
+
+Given a point `p` on the [`Grassmann`](@ref) manifold `M` in Stiefel representation,
+i.e. ``p ∈ ℝ^{n×k}`` reconstruct a tangent vector with respect to the [`DefaultOrthonormalBasis`](@ref)
+given coefficients ``c ∈ ℝ^{k(n-k)}``.
+
+The tangent space is characterized by ``p^{\mathrm{T}}X = 0_{k×k}``,
+where ``0_{k×k}`` is the ``k×k`` matrix containing zeros
+A default orthonormal basis can is constructed as follows: Since ``p`` has full
+column rank ``k``, the null space of ``p^{\mathrm{T}}`` is of dimension ``n-k``.
+Let ``v_1,…v_{n-k}`` be an orthonormal basis of that null space, then
+```math
+X_1 = \bigl(v_1, 0_k,…0_k), X_2 = \bigl(v_2 0_k,…,0_k), …, X_{n-k} = \bigl(v_{n-k} 0_k,…0_k),
+X_{n-k1} = \bigl(0_k, v_1, 0_k, …, 0_k), …, X_{(n-k)k} = (0_k,\ldots,0_k,v_{n-k}),
+```
+where ``0_k`` denotes the ``k``-dimensional zero vector.
+Let ``V = (v_1,…,v_{n-k}) ∈ ℝ^{n×(n-k)}`` be the matrix of the basis vectors.
+
+Reconstructing a tangent vector ``X``` from a vector of coefficients ``c_1,…,c_{k(n-k)}``
+can be done based on the ONB ``v_1,…v_{n-k}``. The ``i``th column ``C_i`` of ``X``
+is given by using “blocks” ``C_1,…C_k ∈ ℝ^{n-k}`` of the coordinates and compute
+
+```math
+X_i = VC_i = \sum_{j=1}^{n-k} c_{i(n-k) + j}v_j,\qquad i=1,…k
+```
+"""
+get_vector(::Grassmann{ℝ}, p, c, ::DefaultOrthonormalBasis)
+
+function get_vector_orthonormal!(M::Grassmann{ℝ}, X, p, c, ::RealNumbers)
+    n, k = get_parameter(M.size)
+    V = nullspace(p') # from SVD, so we have (n-k) ON columns in R^n
+    for i in 1:k
+        # The sum above in the docs is a MV product in blocks c[1:(n-k)], c[(n-k)+1:2*(n-k)],...with V
+        X[:, i] .= V * c[((i - 1) * (n - k) + 1):(i * (n - k))]
+    end
+    return X
+end
 @doc raw"""
     inner(M::Grassmann, p, X, Y)
 
@@ -220,9 +302,7 @@ end
 function parallel_transport_direction!(M::Grassmann, Z, p, X, Y)
     d = svd(Y)
     return copyto!(
-        M,
-        Z,
-        p,
+        M, Z, p,
         (-p * d.V .* sin.(d.S') + d.U .* cos.(d.S')) * (d.U' * X) + (I - d.U * d.U') * X,
     )
 end
@@ -291,11 +371,8 @@ Matrix onto the tangent space at `vector_at`.
 rand(M::Grassmann; σ::Real = 1.0)
 
 function Random.rand!(
-        rng::AbstractRNG,
-        M::Grassmann{𝔽},
-        pX;
-        σ::Real = one(real(eltype(pX))),
-        vector_at = nothing,
+        rng::AbstractRNG, M::Grassmann{𝔽}, pX;
+        σ::Real = one(real(eltype(pX))), vector_at = nothing,
     ) where {𝔽}
     if vector_at === nothing
         n, k = get_parameter(M.size)

--- a/src/manifolds/GrassmannStiefel.jl
+++ b/src/manifolds/GrassmannStiefel.jl
@@ -130,11 +130,7 @@ get_coordinates(::Grassmann{ℝ}, p, c, ::DefaultOrthonormalBasis)
 function get_coordinates_orthonormal!(M::Grassmann{ℝ}, c, p, X, ::RealNumbers)
     n, k = get_parameter(M.size)
     V = nullspace(p') # from SVD, so we have (n-k) ON columns in R^n
-    for i in 1:k
-        # The sum above in the docs is a MV product in blocks
-        # c[1:(n-k)], c[(n-k)+1:2*(n-k)],...with V
-        c[((i - 1) * (n - k) + 1):(i * (n - k))] .= V \ X[:, i]
-    end
+    c .= vec(V \ X)
     return c
 end
 
@@ -189,10 +185,7 @@ get_vector(::Grassmann{ℝ}, p, c, ::DefaultOrthonormalBasis)
 function get_vector_orthonormal!(M::Grassmann{ℝ}, X, p, c, ::RealNumbers)
     n, k = get_parameter(M.size)
     V = nullspace(p') # from SVD, so we have (n-k) ON columns in R^n
-    for i in 1:k
-        # The sum above in the docs is a MV product in blocks c[1:(n-k)], c[(n-k)+1:2*(n-k)],...with V
-        X[:, i] .= V * c[((i - 1) * (n - k) + 1):(i * (n - k))]
-    end
+    mul!(X, V, reshape(c, n - k, k))
     return X
 end
 @doc raw"""

--- a/src/manifolds/Sphere.jl
+++ b/src/manifolds/Sphere.jl
@@ -257,31 +257,31 @@ function ManifoldsBase.get_embedding_type(::AbstractSphere)
 end
 
 @doc raw"""
-    get_vector(M::AbstractSphere{ℝ}, p, X, B::DefaultOrthonormalBasis)
+    get_vector(M::AbstractSphere{ℝ}, p, c, B::DefaultOrthonormalBasis)
 
-Convert a one-dimensional vector of coefficients `X` in the basis `B` of the tangent space
+Convert a one-dimensional vector of coefficients `c` with respect to an orthonormal `B` of the tangent space
 at `p` on the [`AbstractSphere`](@ref) `M` to a tangent vector `Y` at `p` by rotating the
-hyperplane containing `X`, whose normal is the ``x``-axis, to the hyperplane whose normal is
+hyperplane containing `c`, whose normal is the ``x``-axis, to the hyperplane whose normal is
 `p`.
 
-Given ``q = p λ + x``, where ``λ = \operatorname{sgn}(⟨x, p⟩)``, and ``⟨⋅, ⋅⟩_{\mathrm{F}}``
+Given ``q = p λ + c``, where ``λ = \operatorname{sgn}(⟨c, p⟩)``, and ``⟨⋅,⋅⟩_{\mathrm{F}}``
 denotes the Frobenius inner product, the formula for ``Y`` is
 ````math
-Y = X - q\frac{2 \left\langle q, \begin{pmatrix}0 \\ X\end{pmatrix}\right\rangle_{\mathrm{F}}}{⟨q, q⟩_{\mathrm{F}}}.
+Y = c - q\frac{2 \left\langle q, \begin{pmatrix}0 \\ c\end{pmatrix}\right\rangle_{\mathrm{F}}}{⟨q, q⟩_{\mathrm{F}}}.
 ````
 """
-get_vector(::AbstractSphere{ℝ}, p, X, ::DefaultOrthonormalBasis)
+get_vector(::AbstractSphere{ℝ}, p, c, ::DefaultOrthonormalBasis)
 
-function get_vector_orthonormal!(M::AbstractSphere{ℝ}, Y, p, X, ::RealNumbers)
+function get_vector_orthonormal!(M::AbstractSphere{ℝ}, Y, p, c, ::RealNumbers)
     n = manifold_dimension(M)
     p1 = p[1]
     cosθ = abs(p1)
     λ = nzsign(p1, cosθ)
     pend = view(p, 2:(n + 1))
-    pX = dot(pend, X)
+    pX = dot(pend, c)
     factor = pX / (1 + cosθ)
     Y[1] = -λ * pX
-    Y[2:(n + 1)] .= X .- pend .* factor
+    Y[2:(n + 1)] .= c .- pend .* factor
     return Y
 end
 

--- a/test/manifolds-old/grassmann.jl
+++ b/test/manifolds-old/grassmann.jl
@@ -148,6 +148,17 @@ include("../header.jl")
             @test default_vector_transport_method(M, typeof(p)) == ParallelTransport()
             @test default_vector_transport_method(M, typeof(pS)) == ParallelTransport()
         end
+        @testset "A short ONB test" begin
+            M = Grassmann(4, 2)
+            p = [1.0 0.0; 0.0 1.0; 0.0 0.0; 0.0 0.0]
+            c = [1.0, 1.0, 0.0, 0.0]
+            B = DefaultOrthonormalBasis()
+            X = get_vector(M, p, c, B)
+            # might be a bit dependent on nullspace, but it returns an ONB in x3,x4
+            @test X == [0.0 0.0; 0.0 0.0; 1.0 0.0; 1.0 0.0]
+            @test get_coordinates(M, p, X, B) == c
+        end
+
     end
 
     @testset "Complex" begin

--- a/test/test_ambiguities.jl
+++ b/test/test_ambiguities.jl
@@ -46,7 +46,7 @@ end
         ms = Test.detect_ambiguities(Manifolds)
         # Interims solution until we follow what was proposed in
         # https://discourse.julialang.org/t/avoid-ambiguities-with-individual-number-element-identity/62465/2
-        MS_LIMIT = 46
+        MS_LIMIT = 50
         println("Number of Manifolds.jl ambiguities: $(length(ms))")
         if length(ms) > MS_LIMIT
             for amb in ms


### PR DESCRIPTION
This PR introduces an ONB for Grassmann in the Stiefel representation and makes the doc string of the manifold more precise. The old statement of the tangent space was imprecise/wrong.