### PR TITLE
optimize unitary exponential map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,15 @@ All notable changes to ´Manifolds.jl´ will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.28] unreleased
+
+### Changed
+
+* the exponential map for complex `UnitaryMatrices` to use an optimized algorithm for large matrices (#906)
+
 ## [0.11.27] 2026-06-06
 
-## Added
+### Added
 
 * a `DefaultOrthonormalBasis` for the `Grassmann` manifold in Stiefel representation. (#904)
 * improved documentation of the tangent space.

--- a/src/manifolds/GeneralUnitaryMatrices.jl
+++ b/src/manifolds/GeneralUnitaryMatrices.jl
@@ -213,18 +213,18 @@ Compute the exponential map, that is, since ``X`` is represented in the Lie alge
 \exp_p(X) = p\mathrm{e}^X
 ```
 
-For different sizes, like ``n=2,3,4``, there are specialized implementations.
+In the real case there are specialized implementations for ``n=2,3,4``. The algorithm used is a more numerically stable form of those proposed in [GallierXu:2002](@cite) and [AndricaRohan:2013](@cite).
 
-The algorithm used is a more numerically stable form of those proposed in
-[GallierXu:2002](@cite) and [AndricaRohan:2013](@cite).
+In the complex case an eigendecomposition of `im * X` is used for `n ≥ 42`, as benchmarks indicate that it is advantageous for these dimensions.
+
 """
 exp(::GeneralUnitaryMatrices, p, X)
 
 function exp!(M::GeneralUnitaryMatrices, q, p, X)
     return copyto!(M, q, p * exp(X))
 end
-function exp!(M::GeneralUnitaryMatrices{ℂ}, q, p, X)
-    if size(X, 1) < 42
+function exp!(M::GeneralUnitaryMatrices{ℂ, TypeParameter{Tuple{n}}}, q, p, X) where {n}
+    if n < 42
         return copyto!(M, q, p * exp(X))
     else
         return copyto!(M, q, p * _anti_exp(X))

--- a/src/manifolds/GeneralUnitaryMatrices.jl
+++ b/src/manifolds/GeneralUnitaryMatrices.jl
@@ -210,7 +210,7 @@ end
 Compute the exponential map, that is, since ``X`` is represented in the Lie algebra,
 
 ```math
-exp_p(X) = p\mathrm{e}^X
+\exp_p(X) = p\mathrm{e}^X
 ```
 
 For different sizes, like ``n=2,3,4``, there are specialized implementations.
@@ -222,6 +222,18 @@ exp(::GeneralUnitaryMatrices, p, X)
 
 function exp!(M::GeneralUnitaryMatrices, q, p, X)
     return copyto!(M, q, p * exp(X))
+end
+function exp!(M::GeneralUnitaryMatrices{ℂ}, q, p, X)
+    if size(X, 1) < 42
+        return copyto!(M, q, p * exp(X))
+    else
+        return copyto!(M, q, p * _anti_exp(X))
+    end
+end
+function _anti_exp(X)
+    λ, U = eigen(Hermitian(im * X))
+    D = Diagonal(exp.(-im .* λ))
+    return U * D * U'
 end
 function ManifoldsBase.exp_fused!(M::GeneralUnitaryMatrices, q, p, X, t::Number)
     return copyto!(M, q, p * exp(t * X))

--- a/test/manifolds/test_unitary_matrices.jl
+++ b/test/manifolds/test_unitary_matrices.jl
@@ -54,6 +54,14 @@ using LinearAlgebra, Manifolds, Quaternions, Test, ManifoldsBase, StaticArrays
         @test isapprox(M, r, r1; atol = 1.0e-10)
     end
 
+    @testset "Large exp" begin
+        M = UnitaryMatrices(42)
+        p = rand(M)
+        X = randn(42, 42)
+        X = X - X'
+        @test exp(M, p, X) ≈ p * exp(X)
+    end
+
     @testset "Projection with points outside of the manifold" begin
         M = UnitaryMatrices(2)
         pE = [2im 0.0; 0.0 2im]


### PR DESCRIPTION
The exponential map of the unitary manifold was not exploiting the fact that the gradient is anti-Hermitian, which makes it slower for larger dimensions. Funnily enough, my benchmarks showed that the transition point where the overhead is worth it is around dimension 42.

I also tested it for the real case, and my benchmarks showed that it is never worth it, so I only touched the complex one.