### PR TITLE
Use direct SciML owner imports in extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.29] Unreleased
 
+### Changed
+
+* SciML-related extensions now import interfaces and solvers from their owner packages and explicitly trigger on the required SciML weak dependencies.
+
 ### Fixed
 
 * PythonPlot was replaced with GR to fix documentation building on CI.

--- a/Project.toml
+++ b/Project.toml
@@ -33,19 +33,25 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 HybridArrays = "1baab800-613f-4b0a-84e4-9cd3431bfbb9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
+OrdinaryDiffEqVerner = "79d7bb75-1356-48c1-b8c0-6832512096c2"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extensions]
-ManifoldsBoundaryValueDiffEqExt = "BoundaryValueDiffEqMIRK"
+ManifoldsBoundaryValueDiffEqExt = ["BoundaryValueDiffEqMIRK", "SciMLBase"]
 ManifoldsDistributionsExt = ["Distributions", "RecursiveArrayTools"]
 ManifoldsHybridArraysExt = "HybridArrays"
 ManifoldsNLsolveExt = "NLsolve"
 ManifoldsOrdinaryDiffEqDiffEqCallbacksExt = [
   "DiffEqCallbacks",
   "OrdinaryDiffEq",
+  "OrdinaryDiffEqRosenbrock",
+  "OrdinaryDiffEqVerner",
   "RecursiveArrayTools",
+  "SciMLBase",
 ]
 ManifoldsOrdinaryDiffEqExt = "OrdinaryDiffEq"
 ManifoldsRecipesBaseExt = ["Colors", "RecipesBase"]
@@ -70,12 +76,15 @@ Markdown = "1.6"
 MatrixEquations = "2.5, 2.4"
 NLsolve = "4"
 OrdinaryDiffEq = "6.31, 7"
+OrdinaryDiffEqRosenbrock = "2"
+OrdinaryDiffEqVerner = "2"
 Plots = "1"
 PythonCall = "0.9"
 Quaternions = "0.5, 0.6, 0.7"
 Random = "1.6"
 RecipesBase = "1.1"
 RecursiveArrayTools = "2, 3, 4"
+SciMLBase = "3"
 SimpleWeightedGraphs = "1.2"
 SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 StaticArrays = "1.4.3"

--- a/ext/ManifoldsBoundaryValueDiffEqExt.jl
+++ b/ext/ManifoldsBoundaryValueDiffEqExt.jl
@@ -6,7 +6,8 @@ using ManifoldsBase
 using Manifolds: affine_connection
 import Manifolds: solve_chart_log_bvp, estimate_distance_from_bvp
 
-using BoundaryValueDiffEqMIRK
+using BoundaryValueDiffEqMIRK: MIRK4
+using SciMLBase: BVProblem, solve
 
 function chart_log_problem!(du, u, params, t)
     M, A, i = params

--- a/ext/ManifoldsOrdinaryDiffEqDiffEqCallbacksExt.jl
+++ b/ext/ManifoldsOrdinaryDiffEqDiffEqCallbacksExt.jl
@@ -11,7 +11,9 @@ import Manifolds: solve_chart_exp_ode, solve_chart_parallel_transport_ode
 using ManifoldsBase
 
 using DiffEqCallbacks
-using OrdinaryDiffEq: OrdinaryDiffEq, SciMLBase, Rodas5P, AutoVern9, ODEProblem, solve
+using OrdinaryDiffEqRosenbrock: Rodas5P
+using OrdinaryDiffEqVerner: AutoVern9
+using SciMLBase: SciMLBase, ODEProblem, solve
 
 using RecursiveArrayTools: ArrayPartition
 

--- a/src/Manifolds.jl
+++ b/src/Manifolds.jl
@@ -203,11 +203,7 @@ import StatsBase: mean_and_var
 
 using ADTypes:
     AbstractADType,
-    AutoFiniteDiff,
-    AutoFiniteDifferences,
-    AutoForwardDiff,
-    AutoReverseDiff,
-    AutoZygote
+    AutoForwardDiff
 import DifferentiationInterface as DI
 
 using Base.Iterators: repeated


### PR DESCRIPTION
## Summary

- import SciML interface objects directly from `SciMLBase` in the BVP and ODE extension code
- import `Rodas5P` and `AutoVern9` from their owner packages instead of through `OrdinaryDiffEq`
- add the corresponding weakdeps/extension triggers for `SciMLBase`, `OrdinaryDiffEqRosenbrock`, and `OrdinaryDiffEqVerner`
- remove stale unused `ADTypes` imports from the main module

## Motivation

This avoids relying on transitive SciML exports such as `BoundaryValueDiffEqMIRK.BVProblem`, `BoundaryValueDiffEqMIRK.solve`, and `OrdinaryDiffEq.SciMLBase`.

`CommonSolve` is intentionally not added as a direct weakdep; `solve` is imported from `SciMLBase`, which provides the public SciML interface used here.

## Verification

- Fresh extension load check for `ManifoldsBoundaryValueDiffEqExt`
- Fresh extension load check for `ManifoldsOrdinaryDiffEqDiffEqCallbacksExt`
- ExplicitImports rescan of SciML-related findings:
  - `sciml_nonpublic=0`
  - previous BVP/OrdinaryDiffEq transitive SciML findings removed
- `Pkg.test("Manifolds")`
  - `20891` pass
  - `1` broken
  - `20892` total
  - `29m49.6s`
